### PR TITLE
Install Obsidian and Logseq (on macOS)

### DIFF
--- a/configuration-darwin.nix
+++ b/configuration-darwin.nix
@@ -214,11 +214,12 @@
       "utm"
 
       # Productivity
-      "anytype"
+      "anytype" # in beta, not very feature-complete imo
       "google-drive"
       "linear-linear"
       "microsoft-teams"
       "notion"
+      "obsidian" # best-in-class with mobile app support
       "raycast"
       "remarkable"
       "zoom"

--- a/configuration-darwin.nix
+++ b/configuration-darwin.nix
@@ -217,6 +217,7 @@
       "anytype" # in beta, not very feature-complete imo
       "google-drive"
       "linear-linear"
+      "logseq" # FLOSS (compared to Obsidian) but no mobile app
       "microsoft-teams"
       "notion"
       "obsidian" # best-in-class with mobile app support


### PR DESCRIPTION
Evaluated the following tools with verdicts:
- Notion: 
- Anytype: no embeds, no LaTeX, no plugin system
- Org-roam: too Emacs-coupled, no mobile apps, DIY device sync
- Obsidian: closest to Org-roam (but Markdown, more xs-ible), mobile apps, device sync, plugin system
