### PR TITLE
Install nightlight CLI (on macOS)

### DIFF
--- a/configuration-darwin.nix
+++ b/configuration-darwin.nix
@@ -219,6 +219,7 @@
       "linear-linear"
       "logseq" # FLOSS (compared to Obsidian) but no mobile app
       "microsoft-teams"
+      "smudge/smudge/nightlight"
       "notion"
       "obsidian" # best-in-class with mobile app support
       "raycast"

--- a/configuration-darwin.nix
+++ b/configuration-darwin.nix
@@ -214,11 +214,12 @@
       "utm"
 
       # Productivity
-      "anytype"
+      "anytype" # in beta, not very feature-complete imo
       "google-drive"
       "linear-linear"
       "microsoft-teams"
       "notion"
+      "obsidian" # best-in-class with mobile app support
       "raycast"
       "remarkable"
       "zoom"

--- a/configuration-darwin.nix
+++ b/configuration-darwin.nix
@@ -217,6 +217,7 @@
       "anytype" # in beta, not very feature-complete imo
       "google-drive"
       "linear-linear"
+      "logseq" # FLOSS (compared to Obsidian) but no mobile app
       "microsoft-teams"
       "notion"
       "obsidian" # best-in-class with mobile app support

--- a/configuration-darwin.nix
+++ b/configuration-darwin.nix
@@ -201,6 +201,9 @@
         "--verbose"
       ];
     };
+    brews = [
+      "smudge/smudge/nightlight"
+    ];
     casks = [
       # Software Development
       "iterm2"
@@ -219,7 +222,6 @@
       "linear-linear"
       "logseq" # FLOSS (compared to Obsidian) but no mobile app
       "microsoft-teams"
-      "smudge/smudge/nightlight"
       "notion"
       "obsidian" # best-in-class with mobile app support
       "raycast"

--- a/home-darwin.nix
+++ b/home-darwin.nix
@@ -107,4 +107,8 @@
         "workbench.preferredLightColorTheme" = "Default High Contrast Light";
       };
     };
+
+  services.syncthing = {
+    enable = true;
+  };
 }


### PR DESCRIPTION
Installing the `nightlight` CLI tool in order to simplify enabling Night Light
from the terminal and through Raycast.

- feat: Install nightlight CLI tool (for macOS)
