### PR TITLE
Experiment with terminals

### DIFF
--- a/configuration-darwin.nix
+++ b/configuration-darwin.nix
@@ -8,6 +8,7 @@
   # List packages installed in system profile. To search by name, run:
   # $ nix-env -qaP | grep wget
   environment.systemPackages = with pkgs; [
+    alacritty
     asciinema
     bat
     checkmake

--- a/configuration-darwin.nix
+++ b/configuration-darwin.nix
@@ -219,6 +219,7 @@
       "linear-linear"
       "logseq" # FLOSS (compared to Obsidian) but no mobile app
       "microsoft-teams"
+      "smudge/smudge/nightlight"
       "notion"
       "obsidian" # best-in-class with mobile app support
       "raycast"

--- a/configuration-darwin.nix
+++ b/configuration-darwin.nix
@@ -8,7 +8,6 @@
   # List packages installed in system profile. To search by name, run:
   # $ nix-env -qaP | grep wget
   environment.systemPackages = with pkgs; [
-    alacritty
     asciinema
     bat
     checkmake

--- a/configuration-darwin.nix
+++ b/configuration-darwin.nix
@@ -207,6 +207,7 @@
     casks = [
       # Software Development
       "iterm2"
+      "kitty"
 
       # Design
       "figma"

--- a/configuration-darwin.nix
+++ b/configuration-darwin.nix
@@ -7,43 +7,45 @@
 
   # List packages installed in system profile. To search by name, run:
   # $ nix-env -qaP | grep wget
-  environment.systemPackages = [
-    pkgs.asciinema
-    pkgs.bat
-    pkgs.checkmake
-    pkgs.exercism
-    pkgs.gh
-    pkgs.gnumake
-    pkgs.gnupg
-    pkgs.gotop
-    pkgs.hexyl
-    pkgs.html-tidy
-    pkgs.htop
-    pkgs.httpie
-    pkgs.httplab
-    pkgs.jq
-    pkgs.kakoune
-    pkgs.nodePackages.typescript-language-server
-    pkgs.nodejs
-    pkgs.pass
-    pkgs.nixpkgs-fmt
-    pkgs.redis
-    pkgs.rnix-lsp
-    pkgs.shell_gpt
-    pkgs.shellcheck
-    pkgs.shfmt
-    pkgs.sqlite-interactive
-    pkgs.tree
-    pkgs.tree-sitter
-    pkgs.vim
-    pkgs.xxd
-    pkgs.yq
-    inputs.linsk.packages.${pkgs.system}.default
-    inputs.devenv.packages.${pkgs.system}.default
-  ] ++ (if pkgs.system == "aarch64-darwin" then [ ] else [
-    # Drop non Apple Silicon compatible packages
-    pkgs.gdb
-    pkgs.ghidra-bin
+  environment.systemPackages = with pkgs; [
+    asciinema
+    bat
+    checkmake
+    exercism
+    gh
+    gnumake
+    gnupg
+    gotop
+    hexyl
+    html-tidy
+    htop
+    httpie
+    httplab
+    jq
+    kakoune
+    nodePackages.typescript-language-server
+    nodejs
+    pass
+    nixpkgs-fmt
+    redis
+    rnix-lsp
+    shell_gpt
+    shellcheck
+    shfmt
+    sqlite-interactive
+    tree
+    tree-sitter
+    vim
+    xxd
+    yq
+    inputs.linsk.packages.${system}.default
+    inputs.devenv.packages.${system}.default
+  ] ++ (if system == "aarch64-darwin" then [
+    # ARM-only packages
+  ] else [
+    # Intel-only packages
+    gdb
+    ghidra-bin
   ]);
 
   environment.interactiveShellInit = ''

--- a/configuration-darwin.nix
+++ b/configuration-darwin.nix
@@ -214,11 +214,12 @@
       "utm"
 
       # Productivity
-      "anytype"
+      "anytype" # in beta, not very feature-complete imo
       "google-drive"
       "linear-linear"
       "microsoft-teams"
       "notion"
+      "obsidian" # best-in-class with mobile app support
       "raycast"
       "remarkable"
       "zoom"

--- a/configuration-darwin.nix
+++ b/configuration-darwin.nix
@@ -217,6 +217,7 @@
       "anytype" # in beta, not very feature-complete imo
       "google-drive"
       "linear-linear"
+      "logseq" # FLOSS (compared to Obsidian) but no mobile app
       "microsoft-teams"
       "notion"
       "obsidian" # best-in-class with mobile app support

--- a/configuration-darwin.nix
+++ b/configuration-darwin.nix
@@ -201,6 +201,9 @@
         "--verbose"
       ];
     };
+    brews = [
+      "smudge/smudge/nightlight"
+    ];
     casks = [
       # Software Development
       "iterm2"
@@ -219,7 +222,6 @@
       "linear-linear"
       "logseq" # FLOSS (compared to Obsidian) but no mobile app
       "microsoft-teams"
-      "smudge/smudge/nightlight"
       "notion"
       "obsidian" # best-in-class with mobile app support
       "raycast"

--- a/home-darwin.nix
+++ b/home-darwin.nix
@@ -107,4 +107,8 @@
         "workbench.preferredLightColorTheme" = "Default High Contrast Light";
       };
     };
+
+  services.syncthing = {
+    enable = true;
+  };
 }

--- a/home-darwin.nix
+++ b/home-darwin.nix
@@ -10,6 +10,7 @@
   home.stateVersion = "23.05";
 
   home.packages = with pkgs; [
+    alacritty
   ];
 
   # NOTE: Copied from dev.nix


### PR DESCRIPTION
Terminal is great for system theme tracking but doesn't do some basic things
like URL detection. iterm2 is okay but doesn't simplify theme tracking. kitty
and alacritty are other popular terminals that I have to experiment with, so
here goes.

- feat: Install kitty in macOS
- chore: Drop repeated use of pkgs references
- feat: Install alacritty (in macOS)
- fix: Install alacritty with home-manager
