### PR TITLE
Experiment with Emacs (again)

### DIFF
--- a/README.org
+++ b/README.org
@@ -1350,7 +1350,9 @@ ln -s ${PATH_TO_DOTFILE}/conky.conf ${HOME}/.conkyrc
 ln -s ${PATH_TO_DOTFILE}/emacs ${HOME}/.emacs.d
 #+end_src
 
-* Personal Details
+* Configuration
+
+** Personal Details
 
 For developer tooling, we define our =userName= and =userEmail= which we will rely on in configuring git, for example.
 
@@ -1392,7 +1394,7 @@ Observe the snippet below for an example of a valid personal.nix file.
 
 Note that the same configuration above is adapted for macOS by setting =home.homeDirectory= to a valid macOS home path like =/Users/vidbina=.
 
-* nix-darwin
+** nix-darwin
 :PROPERTIES:
 :header-args: :noweb-sep "\n\n"
 :END:
@@ -1430,7 +1432,7 @@ On macOS, nix-darwin provides the most batteries included nix experience. We can
 }
 #+end_src
 
-** Packages
+*** Packages
 
 All packages that are architecture agnostic are installed in all of our macOS machines.
 
@@ -1484,7 +1486,7 @@ ghidra-bin
 It follows that the amount of Intel-only packages will decrease as developers make their applications more readily available.
 #+end_quote
 
-** Setup homebrew
+*** Setup homebrew
 
 #+begin_src nix :noweb-ref nix-darwin-interactive-shellinit
 ''
@@ -1492,7 +1494,7 @@ It follows that the amount of Intel-only packages will decrease as developers ma
 ''
 #+end_src
 
-** Setup nix
+*** Setup nix
 
 #+begin_src nix :noweb-ref nix-darwin
 # Auto upgrade nix package and the daemon service.
@@ -1503,7 +1505,7 @@ services.nix-daemon.enable = true;
 nix.settings.experimental-features = "nix-command flakes";
 #+end_src
 
-** Use gpg-agent
+*** Use gpg-agent
 
 #+begin_src nix :noweb-ref nix-darwin
 # NOTE: Copied from home-linux.nix
@@ -1513,7 +1515,7 @@ programs.gnupg.agent = {
 };
 #+end_src
 
-** Setup zsh
+*** Setup zsh
 
 #+begin_src nix :noweb-ref nix-darwin
 # Create /etc/zshrc that loads the nix-darwin environment.
@@ -1586,7 +1588,7 @@ programs.zsh = {
 };
 #+end_src
 
-** Configure system
+*** Configure system
 
 #+begin_src nix :noweb-ref nix-darwin :noweb yes
 # Set Git commit hash for darwin-version.
@@ -1604,7 +1606,7 @@ system = {
 };
 #+end_src
 
-*** COMMENT Configure system activation scripts
+**** COMMENT Configure system activation scripts
 
 #+begin_src nix :noweb-ref nix-darwin
 # Use activation scripts to set up Spotlight visibility of nix-darwin apps
@@ -1642,7 +1644,7 @@ system.activationScripts.applications.text = lib.mkForce ''
 '';
 #+end_src
 
-** Configure user
+*** Configure user
 
 #+begin_src nix :noweb-ref nix-darwin
 users.users.vidbina = {
@@ -1650,7 +1652,7 @@ users.users.vidbina = {
 };
 #+end_src
 
-** Setup homebrew
+*** Setup homebrew
 
 #+begin_src nix :noweb-ref nix-darwin :noweb yes
 homebrew = {
@@ -1716,8 +1718,8 @@ homebrew = {
 };
 #+end_src
 
-** nix-darwin nixpkgs
-*** Allow some unfree packages
+*** nix-darwin nixpkgs
+**** Allow some unfree packages
 
 #+begin_src nix :noweb-ref nix-darwin :noweb yes
 nixpkgs.config.allowUnfreePredicate = pkg: builtins.elem (lib.getName pkg) [
@@ -1725,7 +1727,7 @@ nixpkgs.config.allowUnfreePredicate = pkg: builtins.elem (lib.getName pkg) [
 ];
 #+end_src
 
-*** Allow some nixpkgs overlays
+**** Allow some nixpkgs overlays
 
 #+begin_src nix :noweb-ref nix-darwin :noweb yes
 nixpkgs.overlays = [
@@ -1736,12 +1738,12 @@ nixpkgs.overlays = [
 ];
 #+end_src
 
-** COMMENT Next
+*** COMMENT Next
 
 #+begin_src nix :noweb-ref nix-darwin
 #+end_src
 
-* Developer Tooling
+** Developer Tooling
 
 We will be tangling this literate configuration into the needed dev.nix file.
 
@@ -1773,7 +1775,7 @@ As an example, you can observe how we direct some comments into the previously d
 # Tangling individual dev tools through nix-devtools noweb reference
 #+end_src
 
-** Git
+*** Git
 
 We tangle the git-related configuration into [[file:dev.nix]] but if you want to manually set things up, check out the [[manual-git][manual git instructions]].
 
@@ -1799,7 +1801,7 @@ programs.git = {
 };
 #+end_src
 
-*** Global Gitignore
+**** Global Gitignore
 
 For convenience we define [[file:git/ignore]] which we want to automatically want to honor in every repo. Based on the instructions in =man gitignore= we stub the =XDG_HOME_CONFIG/.config/git/ignore= and the =~/.gitignore= files to reflect the content of [[file:git/ignore]].
 
@@ -1814,7 +1816,7 @@ home.file = {
 Note that the =programs.git.ignores= setting in home manager can not coexist with the =home.file.".config/git/ignore"= home-manager option. I'm opting for the =home-file= approach since this simplifies updates to merely copying the output of the [[https://www.toptal.com/developers/gitignore][Toptal gitignore generator]]. 😉
 #+end_comment
 
-*** Git LFS
+**** Git LFS
 
 We want LFS enabled.
 
@@ -1822,7 +1824,7 @@ We want LFS enabled.
 lfs.enable = true;
 #+end_src
 
-*** Git Extra Configuration
+**** Git Extra Configuration
 
 Let's opt for naming our default branch "main", using nvim as our editor, using gpg2 are our GPG tool and setting git up to [[https://git-scm.com/docs/git-send-email][send patches by mail]].
 
@@ -1848,7 +1850,7 @@ extraConfig = {
 };
 #+end_src
 
-*** TODO COMMENT Diff: Look into delta or difftastic
+**** TODO COMMENT Diff: Look into delta or difftastic
 
 #+begin_src nix :noweb-ref nix-devtools-git
 delta = {
@@ -1862,73 +1864,73 @@ difftastic = {
 };
 #+end_src
 
-*** GitHub
+**** GitHub
 
 #+begin_src nix :noweb-ref dev-packages
 pkgs.gh
 #+end_src
 
-** Utils
+*** Utils
 
-*** Hex editors/viewers
+**** Hex editors/viewers
 
 #+begin_src nix :noweb-ref dev-packages
 pkgs.xxd
 pkgs.hexyl
 #+end_src
 
-*** Reverse engineering
+**** Reverse engineering
 
 #+begin_src nix :noweb-ref dev-packages
 pkgs.ghidra-bin
 #+end_src
 
-*** Editors
+**** Editors
 
 #+begin_src nix :noweb-ref dev-packages
 pkgs.kakoune
 #+end_src
 
-*** Shell
+**** Shell
 
 #+begin_src nix :noweb-ref dev-packages
 pkgs.shellcheck
 pkgs.shfmt
 #+end_src
 
-***** Asciinema
+****** Asciinema
 
 #+begin_src nix :noweb-ref dev-packages
 pkgs.asciinema
 #+end_src
 
-*** Study
-**** Exercism
+**** Study
+***** Exercism
 
 #+begin_src nix :noweb-ref dev-packages
 pkgs.exercism
 #+end_src
 
-*** HTML, Web
+**** HTML, Web
 
 #+begin_src nix :noweb-ref dev-packages
 pkgs.html-tidy
 #+end_src
 
-**** COMMENT Inspector
+***** COMMENT Inspector
 
 #+begin_src nix :noweb-ref dev-packages
 pkgs.wuzz # cURL-like TUI HTTP request inspection tool
 #+end_src
 
-**** Web Servers
+***** Web Servers
 
 #+begin_src nix :noweb-ref dev-packages
 pkgs.httpie
 pkgs.httplab
 #+end_src
 
-*** TODO GCC
+**** TODO GCC
 
 - State "TODO"       from              [2023-10-03 Tue 18:17] \\
   Verify that glibc is not available for Darwin and merge the separated configs or provide explanation.
@@ -1945,63 +1947,63 @@ For now, isolate the Linux-specific dev packages from the more general dev packa
 pkgs.glibc
 #+end_src
 
-*** COMMENT Haskell
+**** COMMENT Haskell
 
 #+begin_src nix :noweb-ref dev-packages
 pkgs.ghc
 pkgs.ghcid
 #+end_src
 
-*** LSP
-**** Nix
+**** LSP
+***** Nix
 
 #+begin_src nix :noweb-ref dev-packages
 pkgs.rnix-lsp
 #+end_src
 
-**** Typescript Language Server
+***** Typescript Language Server
 
 #+begin_src nix :noweb-ref dev-packages
 pkgs.nodePackages.typescript-language-server
 #+end_src
 
-*** Tree-sitter
+**** Tree-sitter
 
 #+begin_src nix :noweb-ref dev-packages
 pkgs.tree-sitter
 #+end_src
 
-*** DSL
-**** jq, yq
+**** DSL
+***** jq, yq
 
 #+begin_src nix :noweb-ref dev-packages
 pkgs.jq
 pkgs.yq
 #+end_src
 
-*** DB
+**** DB
 
-**** SQLite
+***** SQLite
 
 #+begin_src nix :noweb-ref dev-packages
 pkgs.sqlite-interactive
 #+end_src
 
-**** Redis
+***** Redis
 
 #+begin_src nix :noweb-ref dev-packages
 pkgs.redis
 #+end_src
 
-*** Linux Hacking
+**** Linux Hacking
 
 I have issues with my touchpad often enough and also have issues with Chromium hanging here and there. It's time that I learned to dig into some of the Linux innards and do some good kernel watching.
 
-**** Linux Input Debugging/Kernel Watching
+***** Linux Input Debugging/Kernel Watching
 
 See https://lwn.net/Articles/658948/
 
-***** COMMENT libinput
+****** COMMENT libinput
 
 https://wayland.freedesktop.org/libinput/doc/latest/index.html
 
@@ -2009,7 +2011,7 @@ https://wayland.freedesktop.org/libinput/doc/latest/index.html
 pkgs.libinput
 #+end_src
 
-***** xinput
+****** xinput
 
 1. List xinputs
 
@@ -2023,7 +2025,7 @@ xinput --list
 xinput show-props ID
    #+end_src
 
-***** evemu
+****** evemu
 
 https://www.freedesktop.org/wiki/Evemu/
 https://wiki.ubuntu.com/Multitouch/Testing/Evemu
@@ -2042,7 +2044,7 @@ pkgs.evemu
 evemu-record /dev/input/event13 touchpad-debug.evemu
   #+end_src
 
-***** TODO Debug laggy/choppy touchpad
+****** TODO Debug laggy/choppy touchpad
 
 Recorded some data while I was observing the choppy behavior
 
@@ -2122,15 +2124,15 @@ I can also reproduce that this is related to the palm rejection on the side of t
 I also tried out the mtouch drivers instead of libinput but the problem persists. so I suppose that the problem is related to the firmware of the touchpad.
 #+end_quote
 
-***** TODO mtdiag-qt
+****** TODO mtdiag-qt
 
 https://github.com/bentiss/mtdiag-qt
 
-***** TODO mtview
+****** TODO mtview
 
 https://github.com/whot/mtview
 
-***** COMMENT mtr
+****** COMMENT mtr
 
 https://github.com/traviscross/mtr
 
@@ -2138,7 +2140,7 @@ https://github.com/traviscross/mtr
 pkgs.mtr
 #+end_src
 
-** VsCode
+*** VsCode
 
 #+begin_src nix :noweb-ref darwin-unfree
 "vscode"
@@ -2191,7 +2193,7 @@ defaults.CustomUserPreferences = {
 };
 #+end_src
 
-*** Settings
+**** Settings
 
 #+begin_src nix :noweb-ref vscode-settings
 "editor.cursorSurroundingLines" = 8;
@@ -2207,7 +2209,7 @@ defaults.CustomUserPreferences = {
 "window.autoDetectColorScheme" = true;
 #+end_src
 
-**** Colored guides in VSCode
+***** Colored guides in VSCode
 
 #+begin_src nix :noweb-ref vscode-settings
 # https://www.roboleary.net/2021/11/06/vscode-you-dont-need-that-extension2.html#3-indentation-guides-colorization
@@ -2215,7 +2217,7 @@ defaults.CustomUserPreferences = {
 "editor.guides.highlightActiveIndentation" = true;
 #+end_src
 
-**** Theme configuration in VSCode
+***** Theme configuration in VSCode
 
 #+begin_src nix :noweb-ref vscode-settings
 "workbench.colorTheme" = "Default High Contrast Light";
@@ -2223,7 +2225,7 @@ defaults.CustomUserPreferences = {
 "workbench.preferredLightColorTheme" = "Default High Contrast Light";
 #+end_src
 
-* COMMENT E-mail
+** COMMENT E-mail
 
 We configure file:mail.nix as our mail-related config file.
 
@@ -2246,7 +2248,7 @@ I have used neomutt in combination with Neovim and mu4e in Emacs for nearly half
 }
 #+end_src
 
-** Packages
+*** Packages
 
 The following packages were part of my config before and are just seperated to help me break this down into subordinate chapters:
 
@@ -2257,23 +2259,23 @@ neomutt
 urlview
 #+end_src
 
-*** COMMENT offlineimap
+**** COMMENT offlineimap
 
 #+begin_src nix :noweb-ref mail-packages
 offlineimap
 #+end_src
 
-*** TODO Split out packages into subordinate chapters
+**** TODO Split out packages into subordinate chapters
 
 This is only necessary if I don't end up moving this part of my config entirely into home-manager instead.
 
-** msmtp
+*** msmtp
 
 #+begin_src nix :noweb-ref mail-packages
 msmtp
 #+end_src
 
-** Notmuch
+*** Notmuch
 
 Much of my work-related comms transpires over e-mail. In order to obtain [[https://tongfamily.com/2022/01/22/superhuman-hidden-commands-to-top-and-bottom-are-gg-and-g/][superhuman-level-like-or-better]] 🙊 convenience, I am using [[https://notmuchmail.org/][notmuch]] which has [[https://notmuchmail.org/frontends/][plenty of frontends]] available.
 
@@ -2282,11 +2284,11 @@ notmuch
 notmuch-mutt
 #+end_src
 
-** DONE Workers
+*** DONE Workers
 
 See my private dotfiles where I have defined a mbsync service to handle synchronization of mail. Indexing could be handled through as a =PostExec= hook in the mail retrieval service but this will cause problems with mu4e spinning up mu/server to reindex the maildir and obtaining the read/write lock on the Xapian store.
 
-** COMMENT Issues
+*** COMMENT Issues
 
 #+begin_src text
 sendmail: authentication failed (method PLAIN)
@@ -2294,7 +2296,7 @@ sendmail: server message: 454 4.7.0 Temporary authentication failure:
 sendmail: could not send mail (account work-asabina-gmbh from /home/vidbina/.config/msmtp/config)
 #+end_src
 
-* Neovim
+** Neovim
 
 For Neovim, remember that CoC completions basically work through use of the =C-n= and =C-p= binding to cycle through next and previous items in the completion listing.
 
@@ -2323,7 +2325,7 @@ https://developpaper.com/complete-guide-to-getting-started-with-coc-nvim/
 }
 #+end_src
 
-** Neovim packages
+*** Neovim packages
 
 #+begin_src nix :noweb-ref nvim-packages
 coc-nvim
@@ -2351,23 +2353,23 @@ wmgraphviz-vim
 #+end_src
 
 
-** Make Neovim default editor
+*** Make Neovim default editor
 
-* Emacs
+** Emacs
 
-** Define =my-emacs= as MacPorts build
+*** Define =my-emacs= as MacPorts build
 
 #+begin_src nix :noweb-ref darwin-overlays
 my-emacs = pkgs.emacs-macport;
 #+end_src
 
-** Install Emacs with home-manager
+*** Install Emacs with home-manager
 
 #+begin_src nix :noweb-ref common-imports-darwin
 ./emacs/home.nix
 #+end_src
 
-** Link .emacs.d from dotfiles into home directory
+*** Link .emacs.d from dotfiles into home directory
 
 #+begin_src nix :noweb-ref home-darwin-config
 # home.file.".emacs.d".source = config.lib.file.mkOutOfStoreSymlink ./emacs;
@@ -2380,15 +2382,15 @@ my-emacs = pkgs.emacs-macport;
 home.file.".emacs.d".source = config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/Code/vidbina/dotfiles/emacs";
 #+end_src
 
-** TODO Look into emacs-builds for macOS
+*** TODO Look into emacs-builds for macOS
 
 https://github.com/jimeh/emacs-builds
-* TODO Bring in XMonad configuration
+** TODO Bring in XMonad configuration
 
 For now, I symlink ~/.xmonad to ~/src/vidbina/xmonad-config and run =xmonad --recompile= to produce the Xmonad binary.
 
-* Bars
-** COMMENT TODO Bring in xmobar configuration
+** Bars
+*** COMMENT TODO Bring in xmobar configuration
 
 For now, I symlinked ~/.config/xmobar to ~/src/vidbina/xmobar-configuration.
 
@@ -2399,7 +2401,7 @@ programs.xmobar = {
 };
 #+end_src
 
-** COMMENT polybar
+*** COMMENT polybar
 
 #+begin_src nix
 # TODO: https://gvolpe.com/blog/xmonad-polybar-nixos/
@@ -2410,7 +2412,7 @@ services.taffybar = {
 };
 #+end_src
 
-* Syncthing
+** Syncthing
 
 Navigate to [[http://localhost:8384/][Syncthing portal]] to configure your setup. As per [2022-05-05 Thu 12:08], the syncthing service in home-manager is only declarative to the extend of turning it on and providing extra CLI options to start the service with.
 
@@ -2422,7 +2424,7 @@ services.syncthing = {
 };
 #+end_src
 
-** TODO Set ignore file for Syncthing or move some sensitive stuff out of synced folders
+*** TODO Set ignore file for Syncthing or move some sensitive stuff out of synced folders
 
 Especially for things link mail indices and Org-roam databases, I may need to do this.
 
@@ -2430,7 +2432,7 @@ Especially for things link mail indices and Org-roam databases, I may need to do
 - https://github.com/org-roam/org-roam/issues/977
 - https://github.com/org-roam/org-roam/issues/550
 
-* Multimedia
+** Multimedia
 
 #+begin_src nix :noweb yes :tangle multimedia.nix
 # Tangled from README.org
@@ -2443,7 +2445,7 @@ Especially for things link mail indices and Org-roam databases, I may need to do
 }
 #+end_src
 
-** COMMENT OBS
+*** COMMENT OBS
 
 https://obsproject.com/wiki/install-instructions
 
@@ -2454,7 +2456,7 @@ https://obsproject.com/wiki/install-instructions
 obs-studio
 #+end_src
 
-*** TODO Figure out OpenGL configuration
+**** TODO Figure out OpenGL configuration
 
 We had this binding nixgl into the multimedia.nix block but we are temporariliy ripping this out.
 
@@ -2473,7 +2475,7 @@ This bit we were trying to use to trick OBS into finding OpenGL-related paths. D
 #nixgl {}
 #+end_src
 
-** GTK+ UVC Viewer (GUVCView)
+*** GTK+ UVC Viewer (GUVCView)
 
 https://guvcview.sourceforge.net/
 
@@ -2481,7 +2483,7 @@ https://guvcview.sourceforge.net/
 guvcview
 #+end_src
 
-** V4l utils
+*** V4l utils
 
 https://linuxtv.org/projects.php
 
@@ -2489,7 +2491,7 @@ https://linuxtv.org/projects.php
 v4l-utils
 #+end_src
 
-* Browsers
+** Browsers
 
 #+begin_src nix :noweb yes :tangle browser.nix
 # Tangled from README.org
@@ -2514,7 +2516,7 @@ in
 }
 #+end_src
 
-** COMMENT Chrome
+*** COMMENT Chrome
 
 We just want to try the unfree Google Chrome, to test whether this works with Twitch:
 
@@ -2535,7 +2537,7 @@ chromium --disable-gpu-vsync --disable-frame-rate-limit
 - chrome://gpu
 - chrome://flags/
 
-** DONE Debug Chrome freeze-ups (possibly accelleration-related)
+*** DONE Debug Chrome freeze-ups (possibly accelleration-related)
 
 Output of starting chromium on [2023-03-04 Sat 16:51]
 
@@ -3164,7 +3166,7 @@ https://www.lifewire.com/hardware-acceleration-in-chrome-4125122
 
 Somehow resolved after disabling offloading. Also running chrome as =DISABLE_LAYER_AMD_SWITCHABLE_GRAPHICS_1=1 chromium=.
 
-** DONE Debug Chrome
+*** DONE Debug Chrome
 
 See https://github.com/NixOS/nixpkgs/issues/216361
 
@@ -3186,7 +3188,7 @@ ERR: Display.cpp:1014 (initialize): ANGLE Display::initialize error 12289: Could
 
 Resolved by disabling offloading.
 
-** Chromium
+*** Chromium
 
 #+begin_src nix :noweb yes :noweb-ref browser-chromium
 programs.chromium = {
@@ -3219,7 +3221,7 @@ programs.chromium = {
 
 See https://chromium.googlesource.com/chromium/src/+/refs/heads/main/chrome/common/chrome_switches.cc and https://source.chromium.org/search?q=file:switches.cc&amp;ss=chromium%2Fchromium%2Fsrc for some switches that we can use according to the =commandLineArgs= option in [[https://github.com/nix-community/home-manager/blob/master/modules/programs/chromium.nix][programs/chromium.nix]].
 
-*** Setting environment variable to disable switching
+**** Setting environment variable to disable switching
 
 Note how https://github.com/NixOS/nixpkgs/issues/211408 outlines a fix regarding graphics switching/offloading:
 
@@ -3233,7 +3235,7 @@ We set this through the =home.sessionVariables= option, so we can just run =chro
 home.sessionVariables.DISABLE_LAYER_AMD_SWITCHABLE_GRAPHICS_1 = 1;
 #+end_src
 
-*** Debugging
+**** Debugging
 
 https://www.chromium.org/developers/how-tos/run-chromium-with-flags/
 
@@ -3241,7 +3243,7 @@ chrome://version
 chrome://flags
 chrome://gpu
 
-*** COMMENT Chromium Overlay
+**** COMMENT Chromium Overlay
 
 See https://discourse.nixos.org/t/failed-vaapi-init/23317/3
 
@@ -3251,9 +3253,9 @@ chromium = super.chromium.override {
 };
 #+end_src
 
-*** Extensions
+**** Extensions
 
-**** COMMENT Metamask
+***** COMMENT Metamask
 
 #+begin_src nix :noweb-ref browser-chromium-extensions
   {
@@ -3263,7 +3265,7 @@ chromium = super.chromium.override {
   }
 #+end_src
 
-**** Vimium
+***** Vimium
 
 vi-like navigation of the browser
 
@@ -3277,7 +3279,7 @@ vi-like navigation of the browser
 
 - =c= :: enter caret mode from either of the visual modes (=v= visual mode, =V= visual line mode)
 
-**** Wasavi
+***** Wasavi
 
 vi-editor for input controls
 - enter with =C-RET=, exit with =:q= (typical vi exit command)
@@ -3291,7 +3293,7 @@ vi-editor for input controls
 }
 #+end_src
 
-** Firefox
+*** Firefox
 
 #+begin_quote
 ⚠️ In order to get the extensions in Firefox to work, you may have to first manually enable the extensions.
@@ -3305,7 +3307,7 @@ programs.firefox = {
 };
 #+end_src
 
-*** Extensions
+**** Extensions
 
 #+begin_src nix :noweb yes :noweb-ref browser-firefox-profiles
 # NOTE: Extensions need firefox.profiles to be defined
@@ -3316,7 +3318,7 @@ profiles.personal.extensions =
   ];
 #+end_src
 
-**** Tridactyl
+***** Tridactyl
 
 Tridactyl is the extension introducing the vim bindings into Firefox. It will hijack the body of your new tabs which can bit a bit disruptive to your workflow as it will present a Tridactyl start page which is visually quite busy therefore running =:set newtab about:blank= to clear the body of the new tab can improve the UX and run =:set theme dark= to switch to a dark theme if new tabs are blasting you with white light.
 
@@ -3325,26 +3327,26 @@ multi-account-containers # needed by tridactyl
 tridactyl
 #+end_src
 
-***** Escape Hatch
+****** Escape Hatch
 
 Remember that =<C-,>= (as described in the Tridactyl documentation which would be =C-,= in Emacs bindings notation or more simply but =Ctrl= + =,​=) is the Tridactyl /escape hatch/ that gets you into a part within the page view of the browser where you can use the vi-like bindings to navigate or do this.
 
 💡 This is convenient because loading some pages will leave the focus on the URL bar or the search bar and tabbing through may be a tedious way to get to the page view.
 
-***** Ignore mode
+****** Ignore mode
 
 Remember that =Shift= + =Insert= (or =Ctrl= + =Alt= + =Escape= but I'm refusing to learn that one because it is quite a dragon of a maneuver to efficiently pull of) will toggle to ignore mode in which all keypresses are passed-through to the web application.
 
 💡 This is convenient for applications that have their own bindings that may conflict with Tridactyl.
 
-***** Search
+****** Search
 
 Use =/= to enter a search query and use =Ctrl= + =g= or =Ctrl= + =G= to cycle through search results.
 
 💡 The search cycling binding is a bit differnet to what vi-bindings users may expect so just pay attention to keep =C-g= and =C-G= (expressed in Emacs notation) within (muscle) memory.
 
-** Shared Extensions
-*** WIP GhostText
+*** Shared Extensions
+**** WIP GhostText
 
 Use GhostText to edit text in the browser through a text editor.
 
@@ -3361,7 +3363,7 @@ https://chrome.google.com/webstore/detail/ghosttext/godiecgffnchndlihlpaajjcpleh
 }
 #+end_src
 
-*** Darkreader
+**** Darkreader
 
 #+begin_src nix :noweb-ref browser-chromium-extensions
 {
@@ -3375,7 +3377,7 @@ https://chrome.google.com/webstore/detail/ghosttext/godiecgffnchndlihlpaajjcpleh
 darkreader
 #+end_src
 
-**** Override for mermaid on GitHub
+***** Override for mermaid on GitHub
 
 /html/body/div[1]/div/div/svg/g[2]/rect
 #entity-Document-5b2ba057-c937-56df-837d-8bac67f835ce > rect
@@ -3456,7 +3458,7 @@ div.mermaid .sequenceNumber {
 
 Filed into https://github.com/darkreader/darkreader/pull/11108
 
-**** DXOS Overides
+***** DXOS Overides
 
 #+begin_src css :noweb-ref darkreader-mermaid
 .sidebar {
@@ -3464,8 +3466,8 @@ Filed into https://github.com/darkreader/darkreader/pull/11108
 }
 #+end_src
 
-* Chat
-** Slack
+** Chat
+*** Slack
 
 Using Slack from the browser is a shitty experience because one has to keep so many tabs open for the different workspaces. I'm finally budging and installing the official client.
 
@@ -3477,7 +3479,7 @@ pkgs.slack
 "slack"
 #+end_src
 
-** Discord
+*** Discord
 
 #+begin_src nix :noweb-ref desktop-packages
 pkgs.discord
@@ -3489,7 +3491,7 @@ pkgs.discord
 "discord-canary"
 #+end_src
 
-*** COMMENT Skip Discord host update
+**** COMMENT Skip Discord host update
 
 Tangle single block in order to configure file:~/.config/discord/settings.json such that Discord skips the host update logic as host updates won't work well on NixOS.
 
@@ -3499,7 +3501,7 @@ Tangle single block in order to configure file:~/.config/discord/settings.json s
 }
 #+end_src
 
-* Docs
+** Docs
 
 #+begin_src nix :tangle doc.nix :noweb yes
 # Tangled from README.org
@@ -3514,7 +3516,7 @@ in
 }
 #+end_src
 
-** $LaTeX$
+*** $LaTeX$
 
 #+begin_src nix :noweb yes :noweb-ref doc-let-bindings
 texlive-asabina = with pkgs; (texlive.combine {
@@ -3570,49 +3572,49 @@ bibtex2html
 texlive-asabina
 #+end_src
 
-** PDF
+*** PDF
 
-*** Utilities
+**** Utilities
 
-**** pdftk
+***** pdftk
 
 #+begin_src nix :noweb yes :noweb-ref doc-packages
 pdftk
 #+end_src
 
-**** pandoc
+***** pandoc
 
 #+begin_src nix :noweb yes :noweb-ref doc-packages
 pandoc
 #+end_src
 
-*** Readers
-**** Evince
+**** Readers
+***** Evince
 #+begin_src nix :noweb yes :noweb-ref doc-packages
 evince
 #+end_src
 
-**** Okular
+***** Okular
 
 #+begin_src nix :noweb yes :noweb-ref doc-packages
 okular
 #+end_src
 
-**** Xournal
+***** Xournal
 
 #+begin_src nix :noweb yes :noweb-ref doc-packages
 xournal
 #+end_src
 
-**** Zathura
+***** Zathura
 
 #+begin_src nix :noweb yes :noweb-ref doc-packages
 zathura
 #+end_src
 
-** Dictionaries
+*** Dictionaries
 
-*** Aspell
+**** Aspell
 
 #+begin_src nix :noweb yes :noweb-ref doc-packages
 aspell
@@ -3621,7 +3623,7 @@ aspellDicts.en
 aspellDicts.nl
 #+end_src
 
-*** COMMENT Hunspell
+**** COMMENT Hunspell
 
 #+begin_src nix :noweb yes :noweb-ref doc-let-bindings
 hunspell-personal = with prev;
@@ -3674,27 +3676,27 @@ hunspell-personal = with prev;
 hunspell
 #+end_src
 
-** Spreadsheets
+*** Spreadsheets
 
 #+begin_src nix :noweb yes :noweb-ref doc-packages
 sc-im
 visidata
 #+end_src
 
-** COMMENT Completions
+*** COMMENT Completions
 
 #+begin_src nix :noweb yes :noweb-ref doc-packages
 
 #+end_src
 
-** Misc
-*** QR
+*** Misc
+**** QR
 
 #+begin_src nix :noweb yes :noweb-ref doc-packages
 qrencode
 #+end_src
 
-*** Office
+**** Office
 
 #+begin_src nix :noweb yes :noweb-ref doc-packages
 libreoffice

--- a/README.org
+++ b/README.org
@@ -6,40 +6,6 @@
 
 These dotfiles make my life slightly more convenient. Not promising they'll do the same for yours though. 😉
 
-* TODO [3/22] Convert home-manager config to literate config
-
-Refer to [[file:emacs/README.org]] for an example of a literate config that tangles into multiple output files.
-
-- [-] configuration-darwin.nix
-- [ ] emacs/home.nix
-- [ ] system/darwin.nix
-- [ ] direnv
-- [ ] .xsession
-- [ ] .Xresources.d
-- [ ] .Xmodmap
-- [ ] tmux
-- [ ] Neovim
-- [ ] Termite
-- [ ] Starship
-- [X] Rofi (handled through Pywal since [2023-07-03 Mon])
-- [ ] Redshift (or Gammastep)
-- [ ] Ghorg
-- [ ] Asciinema
-- [ ] Compton
-- [ ] Octave
-- [ ] Lein
-- [ ] Colorit
-- [ ] Conky
-- [X] Emacs
-- [X] Git
-
-* TODO Add MIME types
-
-#+begin_quote conf
-application/pdf=org.pwmt.zathura-pdf-mupdf.desktop;okularApplication_pdf.desktop;
-application/octet-stream=emacsclient.desktop;
-#+end_quote
-
 * Usage
 
 My configuration is currently managed with [[https://github.com/nix-community/home-manager][home-manager]] for the better DX or UX. Before using home-manager, I manually managed symlinks from my config directory to this dotfiles repo. The use of [[https://www.gnu.org/software//stow/][GNU Stow]] was considered for a brief moment until I realized that Stow was written in Perl and I came to terms with my unwillingness to have a critical part of my stack based on tooling that brings me no joy 🙊 (on account of my troubled personal history with Perl).
@@ -3701,6 +3667,40 @@ qrencode
 #+begin_src nix :noweb yes :noweb-ref doc-packages
 libreoffice
 #+end_src
+
+** TODO [3/22] Convert home-manager config to literate config
+
+Refer to [[file:emacs/README.org]] for an example of a literate config that tangles into multiple output files.
+
+- [-] configuration-darwin.nix
+- [ ] emacs/home.nix
+- [ ] system/darwin.nix
+- [ ] direnv
+- [ ] .xsession
+- [ ] .Xresources.d
+- [ ] .Xmodmap
+- [ ] tmux
+- [ ] Neovim
+- [ ] Termite
+- [ ] Starship
+- [X] Rofi (handled through Pywal since [2023-07-03 Mon])
+- [ ] Redshift (or Gammastep)
+- [ ] Ghorg
+- [ ] Asciinema
+- [ ] Compton
+- [ ] Octave
+- [ ] Lein
+- [ ] Colorit
+- [ ] Conky
+- [X] Emacs
+- [X] Git
+
+** TODO Add MIME types
+
+#+begin_quote conf
+application/pdf=org.pwmt.zathura-pdf-mupdf.desktop;okularApplication_pdf.desktop;
+application/octet-stream=emacsclient.desktop;
+#+end_quote
 
 * Local Variables
 

--- a/README.org
+++ b/README.org
@@ -6,10 +6,13 @@
 
 These dotfiles make my life slightly more convenient. Not promising they'll do the same for yours though. 😉
 
-* TODO [3/19] Convert home-manager config to literate config
+* TODO [3/22] Convert home-manager config to literate config
 
 Refer to [[file:emacs/README.org]] for an example of a literate config that tangles into multiple output files.
 
+- [-] configuration-darwin.nix
+- [ ] emacs/home.nix
+- [ ] system/darwin.nix
 - [ ] direnv
 - [ ] .xsession
 - [ ] .Xresources.d
@@ -108,255 +111,7 @@ nix repl
 :?
    #+end_src
 
-The macOS configuration is as follows:
-
-#+begin_src nix :noweb yes :tangle configuration-darwin.nix
-# This is a nix-darwin config
-{ pkgs, lib, inputs, config, username, ... }: {
-  imports = [
-    ./emacs/nix-darwin.nix
-    ./system/darwin
-  ];
-
-  # List packages installed in system profile. To search by name, run:
-  # $ nix-env -qaP | grep wget
-  environment.systemPackages = [
-    pkgs.asciinema
-    pkgs.bat
-    pkgs.checkmake
-    pkgs.exercism
-    pkgs.gh
-    pkgs.gnumake
-    pkgs.gnupg
-    pkgs.gotop
-    pkgs.hexyl
-    pkgs.html-tidy
-    pkgs.htop
-    pkgs.httpie
-    pkgs.httplab
-    pkgs.jq
-    pkgs.kakoune
-    pkgs.nodePackages.typescript-language-server
-    pkgs.nodejs
-    pkgs.pass
-    pkgs.nixpkgs-fmt
-    pkgs.redis
-    pkgs.rnix-lsp
-    pkgs.shellcheck
-    pkgs.shfmt
-    pkgs.sqlite-interactive
-    pkgs.tree
-    pkgs.tree-sitter
-    pkgs.vim
-    pkgs.xxd
-    pkgs.yq
-    inputs.linsk.packages.${pkgs.system}.default
-    inputs.devenv.packages.${pkgs.system}.default
-  ] ++ (if pkgs.system == "aarch64-darwin" then [ ] else [
-    # Drop non Apple Silicon compatible packages
-    pkgs.gdb
-    pkgs.ghidra-bin
-  ]);
-
-  environment.interactiveShellInit = ''
-    eval "''$(${config.homebrew.brewPrefix}/brew shellenv)";
-  '';
-
-  # Auto upgrade nix package and the daemon service.
-  services.nix-daemon.enable = true;
-  # nix.package = pkgs.nix;
-
-  # NOTE: Copied from home-linux.nix
-  programs.gnupg.agent = {
-    enable = true;
-    enableSSHSupport = true;
-  };
-
-  # Necessary for using flakes on this system.
-  nix.settings.experimental-features = "nix-command flakes";
-
-  # Create /etc/zshrc that loads the nix-darwin environment.
-  # NOTE: Copied from common.nix
-  programs.zsh = {
-    enable = true; # default shell on catalina
-    enableSyntaxHighlighting = true;
-    # Used to be initExtraBeforeCompInit
-    # in nix-darwin, interactiveShellInit is called before compinit
-    # see https://github.com/LnL7/nix-darwin/blob/80bb201f4925cdda5a7a3c7b1900fb26bb2af2e8/modules/programs/zsh/default.nix#L168-L176
-
-    promptInit = ''
-      setopt histignorespace # keeps lines preceded with SPACE out of history
-
-      setopt INTERACTIVE_COMMENTS  # allow inline comments like this one
-      # https://github.com/akermu/emacs-libvterm#directory-tracking-and-prompt-tracking
-      vterm_printf(){
-          if [ -n "$TMUX" ] && ([ "''${TERM%%-*}" = "tmux" ] || [ "''${TERM%%-*}" = "screen" ] ); then
-              # Tell tmux to pass the escape sequences through
-              printf "\ePtmux;\e\e]%s\007\e\\" "$1"
-          elif [ "''${TERM%%-*}" = "screen" ]; then
-              # GNU screen (screen, screen-256color, screen-256color-bce)
-              printf "\eP\e]%s\007\e\\" "$1"
-          else
-              printf "\e]%s\e\\" "$1"
-          fi
-      }
-      if [[ "$INSIDE_EMACS" = 'vterm' ]]; then
-          alias clear='vterm_printf "51;Evterm-clear-scrollback";tput clear'
-      fi
-      vterm_prompt_end() {
-          vterm_printf "51;A";
-      }
-      setopt PROMPT_SUBST
-      PROMPT="↪ %(?.%F{green}√.%F{red}%?)%f" # error state
-      PROMPT="$PROMPT → %F{yellow}%~%f" # pwd
-      PROMPT="$PROMPT @ %F{magenta}%D{%Y.%m.%d} %B%F{blue}%T%f%b" # date/time
-      PROMPT="$PROMPT"$'\n'
-      PROMPT="$PROMPT%F{green}>%f " # prompt
-      PROMPT=$PROMPT'%{$(vterm_prompt_end)%}'
-      vterm_cmd() {
-          local vterm_elisp
-          vterm_elisp=""
-          while [ $# -gt 0 ]; do
-              vterm_elisp="$vterm_elisp""$(printf '"%s" ' "$(printf "%s" "$1" | sed -e 's|\\|\\\\|g' -e 's|"|\\"|g')")"
-              shift
-          done
-          vterm_printf "51;E$vterm_elisp"
-      }
-
-      # Workaround to open new tab at pwd
-      # See https://apple.stackexchange.com/a/340778
-      # http://superuser.com/a/315029/4952
-      # Set Apple Terminal.app to resume directory... still necessary 2018-10-26
-      if [[ $TERM_PROGRAM == "Apple_Terminal" ]] && [[ -z "$INSIDE_EMACS" ]] {
-        function chpwd {
-          local SEARCH=' '
-          local REPLACE='%20'
-          local PWD_URL="file://$HOSTNAME''${PWD//$SEARCH/$REPLACE}"
-          printf '\e]7;%s\a' "$PWD_URL"
-        }
-        chpwd
-      }
-
-      # Use vim bindings in zsh
-      bindkey -v
-      # https://unix.stackexchange.com/a/30169
-      bindkey '^R' history-incremental-search-backward
-    '';
-  };
-  # programs.fish.enable = true;
-
-  # Set Git commit hash for darwin-version.
-  system.configurationRevision = inputs.self.rev or inputs.self.dirtyRev or null;
-
-  system.keyboard.enableKeyMapping = true;
-  system.keyboard.remapCapsLockToControl = true;
-
-  # Used for backwards compatibility, please read the changelog before changing.
-  # $ darwin-rebuild changelog
-  system.stateVersion = 4;
-
-  system = {
-    <<darwin-system>>
-  };
-
-  users.users.vidbina = {
-    home = "/Users/vidbina";
-  };
-
-  # Use activation scripts to set up Spotlight visibility of nix-darwin apps
-  # See https://github.com/LnL7/nix-darwin/issues/214#issuecomment-1230730292
-  system.activationScripts.applications.text = lib.mkForce ''
-    echo "setting up ~/Applications..." >&2
-    applications="$HOME/Applications"
-    nix_apps="$applications/Nix Apps"
-
-    # Needs to be writable by the user so that home-manager can symlink into it
-    if ! test -d "$applications"; then
-        mkdir -p "$applications"
-        chown ${username}: "$applications"
-        chmod u+w "$applications"
-    fi
-
-    # Delete the directory to remove old links
-    rm -rf "$nix_apps"
-    mkdir -p "$nix_apps"
-    find ${config.system.build.applications}/Applications -maxdepth 1 -type l -exec readlink '{}' + |
-        while read src; do
-            # Spotlight does not recognize symlinks, it will ignore directory we link to the applications folder.
-            # It does understand MacOS aliases though, a unique filesystem feature. Sadly they cannot be created
-            # from bash (as far as I know), so we use the oh-so-great Apple Script instead.
-            /usr/bin/osascript -e "
-                set fileToAlias to POSIX file \"$src\"
-                set applicationsFolder to POSIX file \"$nix_apps\"
-                tell application \"Finder\"
-                    make alias file to fileToAlias at applicationsFolder
-                    # This renames the alias; 'mpv.app alias' -> 'mpv.app'
-                    set name of result to \"$(rev <<< "$src" | cut -d'/' -f1 | rev)\"
-                end tell
-            " 1>/dev/null
-        done
-  '';
-
-  homebrew = {
-    enable = true;
-    global = {
-      autoUpdate = false;
-    };
-    onActivation = {
-      autoUpdate = false;
-      cleanup = "uninstall";
-      extraFlags = [
-        "--verbose"
-      ];
-    };
-    casks = [
-      # Software Development
-      "iterm2"
-
-      # Design
-      "figma"
-
-      # Containerization & Virtualization
-      "docker"
-      "utm"
-
-      # Productivity
-      "google-drive"
-      "linear-linear"
-      "microsoft-teams"
-      "notion"
-      "raycast"
-      "zoom"
-
-      # Devtools
-      # Go to top-right Settings gear > VSCode Import > Start Import
-      "cursor"
-      "warp"
-
-      # Entertainment
-      "steam"
-      "tidal"
-
-      # Social
-      "discord"
-      "signal"
-      "slack"
-      "telegram"
-      "whatsapp"
-    ];
-  };
-
-  nixpkgs.config.allowUnfreePredicate = pkg: builtins.elem (lib.getName pkg) [
-    <<darwin-unfree>>
-  ];
-
-  nixpkgs.overlays = [
-    (self: super: {
-      <<darwin-overlays>>
-    })
-  ];
-}
-#+end_src
+See the [[*nix-darwin][nix-darwin configuration]] section for configuration/implementation details.
 
 *** WIP Remove latent packages
 
@@ -1295,16 +1050,8 @@ services.trayer = {
 home.stateVersion = "23.05";
 
 home.packages = with pkgs; [
+  <<darwin-home-packages>>
 ];
-
-# home.file.".emacs.d".source = config.lib.file.mkOutOfStoreSymlink ./emacs;
-# TODO: Fix hack of hardcoded dotfiles path
-# NOTE: This repo must be checked out to ~/Code/vidbina/dotfiles
-# A hardcoded .emacs.d source is used because mkOutOfStoreSymlink ./emacs
-# does not seem to work on macOS.
-# See https://discourse.nixos.org/t/accessing-home-manager-config-in-flakes/19864/8
-# See https://github.com/nix-community/home-manager/issues/2085#issuecomment-861427318
-home.file.".emacs.d".source = config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/Code/vidbina/dotfiles/emacs";
 
 # NOTE: Copied from dev.nix
 # TODO: Figure out how to re-use dev.nix config for Darwin and Linux
@@ -1644,6 +1391,355 @@ Observe the snippet below for an example of a valid personal.nix file.
 #+end_src
 
 Note that the same configuration above is adapted for macOS by setting =home.homeDirectory= to a valid macOS home path like =/Users/vidbina=.
+
+* nix-darwin
+:PROPERTIES:
+:header-args: :noweb-sep "\n\n"
+:END:
+
+On macOS, nix-darwin provides the most batteries included nix experience. We can manage services (through launchd), home-manager and homebrew all through a nix configuration.
+
+#+begin_src nix :noweb yes :tangle configuration-darwin.nix
+# This is a nix-darwin config
+{ pkgs, lib, inputs, config, username, ... }: {
+  imports = [
+    # import modules into our nix-darwin config
+    <<nix-darwin-imports>>
+    ./emacs/nix-darwin.nix
+    ./system/darwin
+  ];
+
+  # List packages installed in system profile. To search by name, run:
+  # $ nix-env -qaP | grep wget
+  environment.systemPackages = with pkgs; [
+    <<nix-darwin-packages-common>>
+  ] ++ (if system == "aarch64-darwin" then [
+    # ARM-only packages
+    <<nix-darwin-packages-arm>>
+  ] else [
+    # Intel-only packages
+    <<nix-darwin-packages-intel>>
+  ]);
+
+  environment.interactiveShellInit = lib.strings.concatStrings [
+    <<nix-darwin-interactive-shellinit>>
+  ];
+
+  # General nix-darwin settings
+  <<nix-darwin>>
+}
+#+end_src
+
+** Packages
+
+All packages that are architecture agnostic are installed in all of our macOS machines.
+
+#+begin_src nix :noweb-ref nix-darwin-packages-common
+asciinema
+bat
+checkmake
+exercism
+gh
+gnumake
+gnupg
+gotop
+hexyl
+html-tidy
+htop
+httpie
+httplab
+jq
+kakoune
+nodePackages.typescript-language-server
+nodejs
+pass
+nixpkgs-fmt
+redis
+rnix-lsp
+shell_gpt
+shellcheck
+shfmt
+sqlite-interactive
+tree
+tree-sitter
+vim
+xxd
+yq
+inputs.linsk.packages.${system}.default
+inputs.devenv.packages.${system}.default
+#+end_src
+
+#+begin_src nix :noweb-ref darwin-home-packages
+alacritty
+#+end_src
+
+Intel-only packages are listed separately such that we can use them on the macOS machine that still has a x86-based Intel chip but avoid trying to install them on ARM-based Apple machines.
+
+#+begin_src nix :noweb-ref nix-darwin-packages-intel
+gdb
+ghidra-bin
+#+end_src
+
+#+begin_quote
+It follows that the amount of Intel-only packages will decrease as developers make their applications more readily available.
+#+end_quote
+
+** Setup homebrew
+
+#+begin_src nix :noweb-ref nix-darwin-interactive-shellinit
+''
+  eval "''$(${config.homebrew.brewPrefix}/brew shellenv)";
+''
+#+end_src
+
+** Setup nix
+
+#+begin_src nix :noweb-ref nix-darwin
+# Auto upgrade nix package and the daemon service.
+services.nix-daemon.enable = true;
+# nix.package = pkgs.nix;
+
+# Necessary for using flakes on this system.
+nix.settings.experimental-features = "nix-command flakes";
+#+end_src
+
+** Use gpg-agent
+
+#+begin_src nix :noweb-ref nix-darwin
+# NOTE: Copied from home-linux.nix
+programs.gnupg.agent = {
+  enable = true;
+  enableSSHSupport = true;
+};
+#+end_src
+
+** Setup zsh
+
+#+begin_src nix :noweb-ref nix-darwin
+# Create /etc/zshrc that loads the nix-darwin environment.
+# NOTE: Copied from common.nix
+programs.zsh = {
+  enable = true; # default shell on catalina
+  enableSyntaxHighlighting = true;
+  # Used to be initExtraBeforeCompInit
+  # in nix-darwin, interactiveShellInit is called before compinit
+  # see https://github.com/LnL7/nix-darwin/blob/80bb201f4925cdda5a7a3c7b1900fb26bb2af2e8/modules/programs/zsh/default.nix#L168-L176
+
+  promptInit = ''
+    setopt histignorespace # keeps lines preceded with SPACE out of history
+
+    setopt INTERACTIVE_COMMENTS  # allow inline comments like this one
+    # https://github.com/akermu/emacs-libvterm#directory-tracking-and-prompt-tracking
+    vterm_printf(){
+        if [ -n "$TMUX" ] && ([ "''${TERM%%-*}" = "tmux" ] || [ "''${TERM%%-*}" = "screen" ] ); then
+            # Tell tmux to pass the escape sequences through
+            printf "\ePtmux;\e\e]%s\007\e\\" "$1"
+        elif [ "''${TERM%%-*}" = "screen" ]; then
+            # GNU screen (screen, screen-256color, screen-256color-bce)
+            printf "\eP\e]%s\007\e\\" "$1"
+        else
+            printf "\e]%s\e\\" "$1"
+        fi
+    }
+    if [[ "$INSIDE_EMACS" = 'vterm' ]]; then
+        alias clear='vterm_printf "51;Evterm-clear-scrollback";tput clear'
+    fi
+    vterm_prompt_end() {
+        vterm_printf "51;A";
+    }
+    setopt PROMPT_SUBST
+    PROMPT="↪ %(?.%F{green}√.%F{red}%?)%f" # error state
+    PROMPT="$PROMPT → %F{yellow}%~%f" # pwd
+    PROMPT="$PROMPT @ %F{magenta}%D{%Y.%m.%d} %B%F{blue}%T%f%b" # date/time
+    PROMPT="$PROMPT"$'\n'
+    PROMPT="$PROMPT%F{green}>%f " # prompt
+    PROMPT=$PROMPT'%{$(vterm_prompt_end)%}'
+    vterm_cmd() {
+        local vterm_elisp
+        vterm_elisp=""
+        while [ $# -gt 0 ]; do
+            vterm_elisp="$vterm_elisp""$(printf '"%s" ' "$(printf "%s" "$1" | sed -e 's|\\|\\\\|g' -e 's|"|\\"|g')")"
+            shift
+        done
+        vterm_printf "51;E$vterm_elisp"
+    }
+
+    # Workaround to open new tab at pwd
+    # See https://apple.stackexchange.com/a/340778
+    # http://superuser.com/a/315029/4952
+    # Set Apple Terminal.app to resume directory... still necessary 2018-10-26
+    if [[ $TERM_PROGRAM == "Apple_Terminal" ]] && [[ -z "$INSIDE_EMACS" ]] {
+      function chpwd {
+        local SEARCH=' '
+        local REPLACE='%20'
+        local PWD_URL="file://$HOSTNAME''${PWD//$SEARCH/$REPLACE}"
+        printf '\e]7;%s\a' "$PWD_URL"
+      }
+      chpwd
+    }
+
+    # Use vim bindings in zsh
+    bindkey -v
+    # https://unix.stackexchange.com/a/30169
+    bindkey '^R' history-incremental-search-backward
+  '';
+};
+#+end_src
+
+** Configure system
+
+#+begin_src nix :noweb-ref nix-darwin :noweb yes
+# Set Git commit hash for darwin-version.
+system.configurationRevision = inputs.self.rev or inputs.self.dirtyRev or null;
+
+system.keyboard.enableKeyMapping = true;
+system.keyboard.remapCapsLockToControl = true;
+
+# Used for backwards compatibility, please read the changelog before changing.
+# $ darwin-rebuild changelog
+system.stateVersion = 4;
+
+system = {
+  <<darwin-system>>
+};
+#+end_src
+
+*** COMMENT Configure system activation scripts
+
+#+begin_src nix :noweb-ref nix-darwin
+# Use activation scripts to set up Spotlight visibility of nix-darwin apps
+# See https://github.com/LnL7/nix-darwin/issues/214#issuecomment-1230730292
+system.activationScripts.applications.text = lib.mkForce ''
+  echo "setting up ~/Applications..." >&2
+  applications="$HOME/Applications"
+  nix_apps="$applications/Nix Apps"
+
+  # Needs to be writable by the user so that home-manager can symlink into it
+  if ! test -d "$applications"; then
+      mkdir -p "$applications"
+      chown ${username}: "$applications"
+      chmod u+w "$applications"
+  fi
+
+  # Delete the directory to remove old links
+  rm -rf "$nix_apps"
+  mkdir -p "$nix_apps"
+  find ${config.system.build.applications}/Applications -maxdepth 1 -type l -exec readlink '{}' + |
+      while read src; do
+          # Spotlight does not recognize symlinks, it will ignore directory we link to the applications folder.
+          # It does understand MacOS aliases though, a unique filesystem feature. Sadly they cannot be created
+          # from bash (as far as I know), so we use the oh-so-great Apple Script instead.
+          /usr/bin/osascript -e "
+              set fileToAlias to POSIX file \"$src\"
+              set applicationsFolder to POSIX file \"$nix_apps\"
+              tell application \"Finder\"
+                  make alias file to fileToAlias at applicationsFolder
+                  # This renames the alias; 'mpv.app alias' -> 'mpv.app'
+                  set name of result to \"$(rev <<< "$src" | cut -d'/' -f1 | rev)\"
+              end tell
+          " 1>/dev/null
+      done
+'';
+#+end_src
+
+** Configure user
+
+#+begin_src nix :noweb-ref nix-darwin
+users.users.vidbina = {
+  home = "/Users/vidbina";
+};
+#+end_src
+
+** Setup homebrew
+
+#+begin_src nix :noweb-ref nix-darwin :noweb yes
+homebrew = {
+  enable = true;
+  global = {
+    autoUpdate = false;
+  };
+  onActivation = {
+    autoUpdate = false;
+    cleanup = "uninstall";
+    extraFlags = [
+      "--verbose"
+    ];
+  };
+  brews = [
+    "smudge/smudge/nightlight"
+    "pidof"
+  ];
+  casks = [
+    # Software Development
+    "iterm2"
+    "kitty"
+
+    # Design
+    "figma"
+    "drawio"
+
+    # Containerization & Virtualization
+    "docker"
+    "utm"
+
+    # Productivity
+    "anytype" # in beta, not very feature-complete imo
+    "google-drive"
+    "linear-linear"
+    "logseq" # FLOSS (compared to Obsidian) but no mobile app
+    "microsoft-teams"
+    "notion"
+    "obsidian" # best-in-class with mobile app support
+    "raycast"
+    "remarkable"
+    "zoom"
+
+    # Android
+    "android-file-transfer"
+
+    # Devtools
+    # Go to top-right Settings gear > VSCode Import > Start Import
+    "cursor"
+    "warp"
+
+    # Entertainment
+    "steam"
+    "tidal"
+
+    # Social
+    "discord"
+    "signal"
+    "slack"
+    "telegram"
+    "whatsapp"
+  ];
+};
+#+end_src
+
+** nix-darwin nixpkgs
+*** Allow some unfree packages
+
+#+begin_src nix :noweb-ref nix-darwin :noweb yes
+nixpkgs.config.allowUnfreePredicate = pkg: builtins.elem (lib.getName pkg) [
+  <<darwin-unfree>>
+];
+#+end_src
+
+*** Allow some nixpkgs overlays
+
+#+begin_src nix :noweb-ref nix-darwin :noweb yes
+nixpkgs.overlays = [
+  (self: super: {
+    # nix-darwin overlays
+    <<darwin-overlays>>
+  })
+];
+#+end_src
+
+** COMMENT Next
+
+#+begin_src nix :noweb-ref nix-darwin
+#+end_src
 
 * Developer Tooling
 
@@ -2062,10 +2158,12 @@ programs.vscode =
       bbenoist.nix
       be5invis.toml
       github.copilot
+      hediet.vscode-drawio
       mkhl.direnv
       ms-azuretools.vscode-docker
       ms-python.python
       ms-vscode-remote.remote-containers
+      tomoki1207.pdf
       vscode-org-mode.org-mode
       vscodevim.vim
     ];
@@ -2115,6 +2213,14 @@ defaults.CustomUserPreferences = {
 # https://www.roboleary.net/2021/11/06/vscode-you-dont-need-that-extension2.html#3-indentation-guides-colorization
 "editor.guides.bracketPairs" = true;
 "editor.guides.highlightActiveIndentation" = true;
+#+end_src
+
+**** Theme configuration in VSCode
+
+#+begin_src nix :noweb-ref vscode-settings
+"workbench.colorTheme" = "Default High Contrast Light";
+"workbench.preferredDarkColorTheme" = "Default High Contrast";
+"workbench.preferredLightColorTheme" = "Default High Contrast Light";
 #+end_src
 
 * COMMENT E-mail
@@ -2249,6 +2355,31 @@ wmgraphviz-vim
 
 * Emacs
 
+** Define =my-emacs= as MacPorts build
+
+#+begin_src nix :noweb-ref darwin-overlays
+my-emacs = pkgs.emacs-macport;
+#+end_src
+
+** Install Emacs with home-manager
+
+#+begin_src nix :noweb-ref common-imports-darwin
+./emacs/home.nix
+#+end_src
+
+** Link .emacs.d from dotfiles into home directory
+
+#+begin_src nix :noweb-ref home-darwin-config
+# home.file.".emacs.d".source = config.lib.file.mkOutOfStoreSymlink ./emacs;
+# TODO: Fix hack of hardcoded dotfiles path
+# NOTE: This repo must be checked out to ~/Code/vidbina/dotfiles
+# A hardcoded .emacs.d source is used because mkOutOfStoreSymlink ./emacs
+# does not seem to work on macOS.
+# See https://discourse.nixos.org/t/accessing-home-manager-config-in-flakes/19864/8
+# See https://github.com/nix-community/home-manager/issues/2085#issuecomment-861427318
+home.file.".emacs.d".source = config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/Code/vidbina/dotfiles/emacs";
+#+end_src
+
 ** TODO Look into emacs-builds for macOS
 
 https://github.com/jimeh/emacs-builds
@@ -2284,6 +2415,12 @@ services.taffybar = {
 Navigate to [[http://localhost:8384/][Syncthing portal]] to configure your setup. As per [2022-05-05 Thu 12:08], the syncthing service in home-manager is only declarative to the extend of turning it on and providing extra CLI options to start the service with.
 
 Consult the [[https://docs.syncthing.net/intro/getting-started.html][Getting Started]] guide to learn how to set it up "imperatively" (i.e.: setting up peers and generating their IDs and copying the needed information over to the other syncthing peers to establish connections) through the portal.
+
+#+begin_src nix :noweb-ref home-darwin-config
+services.syncthing = {
+  enable = true;
+};
+#+end_src
 
 ** TODO Set ignore file for Syncthing or move some sensitive stuff out of synced folders
 

--- a/README.org
+++ b/README.org
@@ -2247,6 +2247,11 @@ wmgraphviz-vim
 
 ** Make Neovim default editor
 
+* Emacs
+
+** TODO Look into emacs-builds for macOS
+
+https://github.com/jimeh/emacs-builds
 * TODO Bring in XMonad configuration
 
 For now, I symlink ~/.xmonad to ~/src/vidbina/xmonad-config and run =xmonad --recompile= to produce the Xmonad binary.

--- a/configuration-darwin.nix
+++ b/configuration-darwin.nix
@@ -8,6 +8,7 @@
   # List packages installed in system profile. To search by name, run:
   # $ nix-env -qaP | grep wget
   environment.systemPackages = with pkgs; [
+    alacritty
     asciinema
     bat
     checkmake

--- a/configuration-darwin.nix
+++ b/configuration-darwin.nix
@@ -259,6 +259,7 @@
   nixpkgs.overlays = [
     (self: super: {
       my-vscode-extensions = inputs.vscode-extensions.extensions.${pkgs.system};
+      my-emacs = pkgs.emacs-macport;
     })
   ];
 }

--- a/configuration-darwin.nix
+++ b/configuration-darwin.nix
@@ -157,39 +157,40 @@
     home = "/Users/vidbina";
   };
 
-  # Use activation scripts to set up Spotlight visibility of nix-darwin apps
-  # See https://github.com/LnL7/nix-darwin/issues/214#issuecomment-1230730292
-  system.activationScripts.applications.text = lib.mkForce ''
-    echo "setting up ~/Applications..." >&2
-    applications="$HOME/Applications"
-    nix_apps="$applications/Nix Apps"
+  # # Use activation scripts to set up Spotlight visibility of nix-darwin apps
+  # # - https://github.com/LnL7/nix-darwin/issues/214#issuecomment-1230730292
+  # # - https://github.com/nix-community/home-manager/issues/1341
+  # system.activationScripts.applications.text = lib.mkForce ''
+  #   echo "setting up ~/Applications..." >&2
+  #   applications="$HOME/Applications"
+  #   nix_apps="$applications/Nix Apps"
 
-    # Needs to be writable by the user so that home-manager can symlink into it
-    if ! test -d "$applications"; then
-        mkdir -p "$applications"
-        chown ${username}: "$applications"
-        chmod u+w "$applications"
-    fi
+  #   # Needs to be writable by the user so that home-manager can symlink into it
+  #   if ! test -d "$applications"; then
+  #       mkdir -p "$applications"
+  #       chown ${username}: "$applications"
+  #       chmod u+w "$applications"
+  #   fi
 
-    # Delete the directory to remove old links
-    rm -rf "$nix_apps"
-    mkdir -p "$nix_apps"
-    find ${config.system.build.applications}/Applications -maxdepth 1 -type l -exec readlink '{}' + |
-        while read src; do
-            # Spotlight does not recognize symlinks, it will ignore directory we link to the applications folder.
-            # It does understand MacOS aliases though, a unique filesystem feature. Sadly they cannot be created
-            # from bash (as far as I know), so we use the oh-so-great Apple Script instead.
-            /usr/bin/osascript -e "
-                set fileToAlias to POSIX file \"$src\"
-                set applicationsFolder to POSIX file \"$nix_apps\"
-                tell application \"Finder\"
-                    make alias file to fileToAlias at applicationsFolder
-                    # This renames the alias; 'mpv.app alias' -> 'mpv.app'
-                    set name of result to \"$(rev <<< "$src" | cut -d'/' -f1 | rev)\"
-                end tell
-            " 1>/dev/null
-        done
-  '';
+  #   # Delete the directory to remove old links
+  #   rm -rf "$nix_apps"
+  #   mkdir -p "$nix_apps"
+  #   find ${config.system.build.applications}/Applications -maxdepth 1 -type l -exec readlink '{}' + |
+  #       while read src; do
+  #           # Spotlight does not recognize symlinks, it will ignore directory we link to the applications folder.
+  #           # It does understand MacOS aliases though, a unique filesystem feature. Sadly they cannot be created
+  #           # from bash (as far as I know), so we use the oh-so-great Apple Script instead.
+  #           /usr/bin/osascript -e "
+  #               set fileToAlias to POSIX file \"$src\"
+  #               set applicationsFolder to POSIX file \"$nix_apps\"
+  #               tell application \"Finder\"
+  #                   make alias file to fileToAlias at applicationsFolder
+  #                   # This renames the alias; 'mpv.app alias' -> 'mpv.app'
+  #                   set name of result to \"$(rev <<< "$src" | cut -d'/' -f1 | rev)\"
+  #               end tell
+  #           " 1>/dev/null
+  #       done
+  # '';
 
   homebrew = {
     enable = true;

--- a/configuration-darwin.nix
+++ b/configuration-darwin.nix
@@ -219,6 +219,7 @@
       "linear-linear"
       "logseq" # FLOSS (compared to Obsidian) but no mobile app
       "microsoft-teams"
+      "smudge/smudge/nightlight"
       "notion"
       "obsidian" # best-in-class with mobile app support
       "raycast"

--- a/configuration-darwin.nix
+++ b/configuration-darwin.nix
@@ -8,7 +8,6 @@
   # List packages installed in system profile. To search by name, run:
   # $ nix-env -qaP | grep wget
   environment.systemPackages = with pkgs; [
-    alacritty
     asciinema
     bat
     checkmake

--- a/configuration-darwin.nix
+++ b/configuration-darwin.nix
@@ -207,6 +207,7 @@
     casks = [
       # Software Development
       "iterm2"
+      "kitty"
 
       # Design
       "figma"

--- a/configuration-darwin.nix
+++ b/configuration-darwin.nix
@@ -7,43 +7,45 @@
 
   # List packages installed in system profile. To search by name, run:
   # $ nix-env -qaP | grep wget
-  environment.systemPackages = [
-    pkgs.asciinema
-    pkgs.bat
-    pkgs.checkmake
-    pkgs.exercism
-    pkgs.gh
-    pkgs.gnumake
-    pkgs.gnupg
-    pkgs.gotop
-    pkgs.hexyl
-    pkgs.html-tidy
-    pkgs.htop
-    pkgs.httpie
-    pkgs.httplab
-    pkgs.jq
-    pkgs.kakoune
-    pkgs.nodePackages.typescript-language-server
-    pkgs.nodejs
-    pkgs.pass
-    pkgs.nixpkgs-fmt
-    pkgs.redis
-    pkgs.rnix-lsp
-    pkgs.shell_gpt
-    pkgs.shellcheck
-    pkgs.shfmt
-    pkgs.sqlite-interactive
-    pkgs.tree
-    pkgs.tree-sitter
-    pkgs.vim
-    pkgs.xxd
-    pkgs.yq
-    inputs.linsk.packages.${pkgs.system}.default
-    inputs.devenv.packages.${pkgs.system}.default
-  ] ++ (if pkgs.system == "aarch64-darwin" then [ ] else [
-    # Drop non Apple Silicon compatible packages
-    pkgs.gdb
-    pkgs.ghidra-bin
+  environment.systemPackages = with pkgs; [
+    asciinema
+    bat
+    checkmake
+    exercism
+    gh
+    gnumake
+    gnupg
+    gotop
+    hexyl
+    html-tidy
+    htop
+    httpie
+    httplab
+    jq
+    kakoune
+    nodePackages.typescript-language-server
+    nodejs
+    pass
+    nixpkgs-fmt
+    redis
+    rnix-lsp
+    shell_gpt
+    shellcheck
+    shfmt
+    sqlite-interactive
+    tree
+    tree-sitter
+    vim
+    xxd
+    yq
+    inputs.linsk.packages.${system}.default
+    inputs.devenv.packages.${system}.default
+  ] ++ (if system == "aarch64-darwin" then [
+    # ARM-only packages
+  ] else [
+    # Intel-only packages
+    gdb
+    ghidra-bin
   ]);
 
   environment.interactiveShellInit = ''

--- a/configuration-darwin.nix
+++ b/configuration-darwin.nix
@@ -206,6 +206,7 @@
     };
     brews = [
       "smudge/smudge/nightlight"
+      "pidof"
     ];
     casks = [
       # Software Development

--- a/configuration-darwin.nix
+++ b/configuration-darwin.nix
@@ -214,11 +214,12 @@
       "utm"
 
       # Productivity
-      "anytype"
+      "anytype" # in beta, not very feature-complete imo
       "google-drive"
       "linear-linear"
       "microsoft-teams"
       "notion"
+      "obsidian" # best-in-class with mobile app support
       "raycast"
       "remarkable"
       "zoom"

--- a/configuration-darwin.nix
+++ b/configuration-darwin.nix
@@ -217,6 +217,7 @@
       "anytype" # in beta, not very feature-complete imo
       "google-drive"
       "linear-linear"
+      "logseq" # FLOSS (compared to Obsidian) but no mobile app
       "microsoft-teams"
       "notion"
       "obsidian" # best-in-class with mobile app support

--- a/configuration-darwin.nix
+++ b/configuration-darwin.nix
@@ -201,6 +201,9 @@
         "--verbose"
       ];
     };
+    brews = [
+      "smudge/smudge/nightlight"
+    ];
     casks = [
       # Software Development
       "iterm2"
@@ -219,7 +222,6 @@
       "linear-linear"
       "logseq" # FLOSS (compared to Obsidian) but no mobile app
       "microsoft-teams"
-      "smudge/smudge/nightlight"
       "notion"
       "obsidian" # best-in-class with mobile app support
       "raycast"

--- a/emacs/README.org
+++ b/emacs/README.org
@@ -2381,7 +2381,7 @@ In order to avoid overthinking themes, I've opted for Prot's [[https://gitlab.co
 
 *** Theme Magic
 
-Use [[https://github.com/jcaw/theme-magic][theme-magic]] to use pywal to update your system theme based on your current Emacs theme.
+The [[https://github.com/jcaw/theme-magic][theme-magic]] package uses [[https://github.com/dylanaraps/pywal][pywal]] to update terminal emulator color schemes or themes. Using theme-magic allows one to syncs the terminal themes to the current Emacs theme.
 
 #+begin_src elisp :tangle init.el
 (use-package theme-magic
@@ -2391,6 +2391,19 @@ Use [[https://github.com/jcaw/theme-magic][theme-magic]] to use pywal to update 
   :config
   (theme-magic-export-theme-mode))
 #+end_src
+
+Run the =theme-magic-from-emacs= command to update your system theme to match your Emacs theme.
+
+#+begin_aside
+Note that on macOS, theme-magic works with iTerm2 out of the box. Other terminal emulators like Alacritty and Kitty may take additional configuration to set up.
+#+end_aside
+
+Pywal provides instructions on the [[https://github.com/dylanaraps/pywal/wiki/Installation#terminal-emulator][terminal emulators]] that are compatible and how to test them, note that the following terminals are known to not work well with pywal:
+- Konsole (the KDE standard)
+- Hyper (the web-based Vercel)
+- Terminal.app (the macOS standard)
+- Terminology (the Enlightenment EFL standard)
+- st (the suckless standard)
 
 ** COMMENT NΛNO: NANO Theme by Rougier
 

--- a/emacs/README.org
+++ b/emacs/README.org
@@ -7720,6 +7720,17 @@ in
 }
 #+end_src
 
+**** Emacs (launchd) service through nix-darwin and package through (home-manager)
+
+In order to avoid having to figure out the mess with activation scripts, we can install the Emacs service through nix-darwin such that we have the long-running daemon available and simultaneously install the same Emacs as a home-manager package, such that we have the Spotlight-visible reference created for us (in the ~/Applications/Home Manager Apps directory). It is important to install the exact same version of Emacs in nix-darwin as well as home-manager to avoid version incompatibility issues.
+
+#+begin_src nix :noweb yes :noweb-ref nix-darwin
+services.emacs = {
+  enable = true;
+  package = pkgs.my-emacs;
+};
+#+end_src
+
 **** TODO COMMENT Experiment with Emacs plus
 
 https://github.com/d12frosted/homebrew-emacs-plus#options

--- a/emacs/home.nix
+++ b/emacs/home.nix
@@ -7,7 +7,7 @@
   # does not seem to work on macOS.
   # See https://discourse.nixos.org/t/accessing-home-manager-config-in-flakes/19864/8
   # See https://github.com/nix-community/home-manager/issues/2085#issuecomment-861427318
-  # home.file.".emacs.d".source = config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/Code/vidbina/dotfiles/emacs";
+  home.file.".emacs.d".source = config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/Code/vidbina/dotfiles/emacs";
 
   home.packages = with pkgs; [
     my-emacs

--- a/emacs/home.nix
+++ b/emacs/home.nix
@@ -7,5 +7,5 @@
   # does not seem to work on macOS.
   # See https://discourse.nixos.org/t/accessing-home-manager-config-in-flakes/19864/8
   # See https://github.com/nix-community/home-manager/issues/2085#issuecomment-861427318
-  home.file.".emacs.d".source = config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/Code/vidbina/dotfiles/emacs";
+  # home.file.".emacs.d".source = config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/Code/vidbina/dotfiles/emacs";
 }

--- a/emacs/home.nix
+++ b/emacs/home.nix
@@ -11,5 +11,6 @@
 
   home.packages = with pkgs; [
     my-emacs
+    pywal
   ];
 }

--- a/emacs/home.nix
+++ b/emacs/home.nix
@@ -8,4 +8,8 @@
   # See https://discourse.nixos.org/t/accessing-home-manager-config-in-flakes/19864/8
   # See https://github.com/nix-community/home-manager/issues/2085#issuecomment-861427318
   # home.file.".emacs.d".source = config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/Code/vidbina/dotfiles/emacs";
+
+  home.packages = with pkgs; [
+    my-emacs
+  ];
 }

--- a/emacs/nix-darwin.nix
+++ b/emacs/nix-darwin.nix
@@ -14,5 +14,8 @@
 
   ];
 
-
+  services.emacs = {
+    enable = true;
+    package = pkgs.my-emacs;
+  };
 }

--- a/emacs/nix-darwin.nix
+++ b/emacs/nix-darwin.nix
@@ -1,5 +1,5 @@
 # Tangled from README.org
-{ pkgs, ... }:
+{ config, pkgs, ... }:
 
 {
   environment.systemPackages = with pkgs; [
@@ -14,8 +14,14 @@
 
   ];
 
-  services.emacs = {
-    enable = true;
-    package = pkgs.my-emacs;
+  # based on https://github.com/LnL7/nix-darwin/blob/0dd382b70c351f528561f71a0a7df82c9d2be9a4/modules/services/emacs.nix#L45-L50
+  launchd.user.agents.my-emacs = {
+    path = [ config.environment.systemPath ];
+    serviceConfig = {
+      ProgramArguments = [ "${pkgs.my-emacs}/bin/emacs" "--fg-daemon=main" ];
+      RunAtLoad = true;
+      StandardErrorPath = "/tmp/emacs.stderr.log";
+      StandardOutPath = "/tmp/emacs.stdout.log";
+    };
   };
 }

--- a/home-darwin.nix
+++ b/home-darwin.nix
@@ -102,13 +102,19 @@
         # https://www.roboleary.net/2021/11/06/vscode-you-dont-need-that-extension2.html#3-indentation-guides-colorization
         "editor.guides.bracketPairs" = true;
         "editor.guides.highlightActiveIndentation" = true;
-
         "workbench.colorTheme" = "Default High Contrast Light";
         "workbench.preferredDarkColorTheme" = "Default High Contrast";
         "workbench.preferredLightColorTheme" = "Default High Contrast Light";
       };
     };
-
+  # home.file.".emacs.d".source = config.lib.file.mkOutOfStoreSymlink ./emacs;
+  # TODO: Fix hack of hardcoded dotfiles path
+  # NOTE: This repo must be checked out to ~/Code/vidbina/dotfiles
+  # A hardcoded .emacs.d source is used because mkOutOfStoreSymlink ./emacs
+  # does not seem to work on macOS.
+  # See https://discourse.nixos.org/t/accessing-home-manager-config-in-flakes/19864/8
+  # See https://github.com/nix-community/home-manager/issues/2085#issuecomment-861427318
+  home.file.".emacs.d".source = config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/Code/vidbina/dotfiles/emacs";
   services.syncthing = {
     enable = true;
   };

--- a/home-darwin.nix
+++ b/home-darwin.nix
@@ -107,4 +107,8 @@
         "workbench.preferredLightColorTheme" = "Default High Contrast Light";
       };
     };
+
+  services.syncthing = {
+    enable = true;
+  };
 }

--- a/home-darwin.nix
+++ b/home-darwin.nix
@@ -10,6 +10,7 @@
   home.stateVersion = "23.05";
 
   home.packages = with pkgs; [
+    alacritty
   ];
 
   # NOTE: Copied from dev.nix


### PR DESCRIPTION
Trying to install Emacs again from a clean slate. Some ideas are to conduct a
standard **nix-darwin service** installation and a **home-manager package**
installation where we install the same package every time through the
`my-emacs` overlayed package to ensure that both installations are always
compatible.

- chore(temp): Unlink .emacs.d
- feat: Install same Emacs as hm pkg+nix-darwin svc
- chore: Disable hacky nix-darwin activationScript
- chore: Relink emacs dotfiles
