### PR TITLE
feat: expand /linearissue to support issue iteration

### DIFF
--- a/claude/skills/linearissue/SKILL.md
+++ b/claude/skills/linearissue/SKILL.md
@@ -15,6 +15,8 @@ The defining design principles of this skill are:
 > **Confirm in chat, not via files.** The skill prints proposed tickets in the conversation, confirms with one `AskUserQuestion`, and creates on approval. One invocation, one session.
 >
 > **Idempotent re-runs.** A note that's already been linearized has inline `Linear: LIN-NNN` annotations. The skill detects them and updates instead of duplicating.
+>
+> **Issues are minimal anchors; comments carry the thinking.** A ticket's title and description are a stable, concise anchor — what the work is, nothing more. Scope crystallization (additions, reductions, pushback, context, reasoning) happens through comments, which are immutable and preserve the history of thinking. Keep descriptions short and pragmatic. Never use them as a context dump from the design note — the backlink to the note is enough. This principle applies in both filing mode and iteration mode.
 
 ## How this fits the broader workflow
 
@@ -170,7 +172,7 @@ If the user bails, stop. Print nothing further.
 For each confirmed ticket:
 
 1. **Existing detection.** If the note's source-anchor area already has an inline `Linear: LIN-NNN` annotation, or if a Linear search by source anchor URL in the description footer finds an existing ticket, treat as **update**. Otherwise **create**.
-2. **Create:** call `save_issue` with team, project, title, description (including the source-anchor footer), priority, parent (if dependency-hinted as a sub-task — but default to flat unless the note structure clearly implies sub-tasking).
+2. **Create:** call `save_issue` with team, project, title, description (including the source-anchor footer), priority, parent (if dependency-hinted as a sub-task — but default to flat unless the note structure clearly implies sub-tasking). Keep the description to 2–4 sentences maximum: one sentence on what the work is, one sentence on why it matters (if not obvious), and the source-anchor backlink. Do not copy prose, context, or reasoning from the design note into the description — the backlink is the bridge. If there is important context that should accompany the ticket, post it as a comment after creation instead.
 3. **Update:** call `save_issue` with `id` set to the existing `LIN-NNN`, updating only fields that have meaningfully changed (description content, priority). Don't touch state, assignee, or labels unless explicitly indicated.
 4. **Capture** the returned ticket ID and URL.
 
@@ -213,6 +215,7 @@ Print:
 - **Don't interpret non-canonical sections creatively.** Only known sections and explicit `→ ticket` markers count. If a note has work in a non-canonical section, ask in Phase 3.
 - **Don't infer parallel-safety from nothing.** If the note doesn't mention file scope or parallelism, leave parallel-safety unset. Don't fabricate predictions.
 - **Don't bundle unrelated action items into a single ticket.** One action item = one ticket. If items are tightly coupled, the note should reflect that and the skill can model them as parent/sub-tasks — but only if the note is structured that way.
+- **Don't over-fill descriptions.** A description is a minimal anchor — 2–4 sentences max. Do not copy prose, reasoning, or context from the design note into it. The backlink to the note is the bridge; if extra context is needed, post it as a comment after creation. Stuffing descriptions creates maintenance debt and obscures the signal.
 - **Don't ask more than one round of clarification** (the "Exclude some" follow-up is the only permitted second question). If something surfaces during creation that should have been asked, note it in the summary and stop.
 - **Don't follow URLs unbounded.** Use `WebFetch` only to enrich descriptions for URLs *already referenced in the note*, not to search the web. This skill is deterministic; research belongs in `designnote`.
 

--- a/claude/skills/linearissue/SKILL.md
+++ b/claude/skills/linearissue/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: linearissue
-description: "Use this skill when the user asks you to turn a design note's action items into Linear issues — filing tickets from a note, linearizing the todos in a note, creating Linear issues from pending work in a design note, or shipping a note's action items to Linear for execution. Trigger for prompts like 'file tickets from this note', 'linearize X', 'create Linear issues for the action items in X', 'turn this note into tickets', 'ship this to Linear', 'file these TODOs from the design note', 'make tickets from X', 'linearissue this note', 'create issues from X.md'. Also trigger when the user invokes `/linearissue`. The skill reads a specific design note (or the most recent TODO/WIP note if not specified), parses its action items from canonical sections (## Action items, ## Next Action, ## Trigger Points, and inline checklists), prints a proposed-tickets summary in chat, confirms via AskUserQuestion, then creates the Linear issues and appends bidirectional cross-references back into the note. It refuses to run on DONE, SUPERSEDED, CANCELED, DEPRECATED notes, or anything in `ARCHIVE/`. Do NOT trigger for ad-hoc ticket creation not derived from a note (use the Linear MCP directly), for updating existing tickets in arbitrary ways (use the Linear MCP directly), for creating Linear documents (that's the designnote skill's strategy-routing path), for filing tickets from `docs/decisions/` ADRs (decisions are made; they don't spawn tickets), or for any operation that would also commit to git."
+description: "Use this skill when the user asks you to turn a design note's action items into Linear issues, OR when the user wants to iterate on an existing Linear issue. Filing mode triggers: 'file tickets from this note', 'linearize X', 'create Linear issues for the action items in X', 'turn this note into tickets', 'ship this to Linear', 'file these TODOs from the design note', 'make tickets from X', 'linearissue this note', 'create issues from X.md'. Iteration mode triggers: user passes a Linear issue URL (e.g. https://linear.app/...) or issue ID (e.g. VID-123) with a follow-on prompt like 'help me refine this', 'roast this scope', 'add context about X', 'what questions should we answer first', 'sharpen the description', or any request to think about, improve, or comment on an existing issue. Also trigger when the user invokes `/linearissue`. Do NOT trigger for creating Linear documents (that's the designnote skill's strategy-routing path), for filing tickets from `docs/decisions/` ADRs (decisions are made; they don't spawn tickets), or for any operation that would also commit to git."
 allowed-tools: Glob Grep Read Edit WebFetch AskUserQuestion mcp__claude_ai_Linear__list_issues mcp__claude_ai_Linear__get_issue mcp__claude_ai_Linear__save_issue mcp__claude_ai_Linear__list_comments mcp__claude_ai_Linear__save_comment mcp__claude_ai_Linear__list_teams mcp__claude_ai_Linear__get_team mcp__claude_ai_Linear__list_projects mcp__claude_ai_Linear__get_project mcp__claude_ai_Linear__list_issue_statuses mcp__claude_ai_Linear__list_issue_labels
 ---
 
@@ -56,7 +56,14 @@ The skill does not declare `Write` — it never creates new files. It only edits
 
 ## Phase 0 — Preflight
 
-### Parse invocation
+### Parse invocation and detect mode
+
+Examine the first argument (or the full prompt if no explicit argument):
+
+- **Iteration mode** — if the input contains a Linear issue URL (`https://linear.app/...`) or a bare issue identifier matching the pattern `[A-Z]+-\d+` (e.g. `VID-123`, `Z-419`), enter **iteration mode**. Capture the issue ID and the rest of the prompt as the user's intent. Skip to the [Iteration mode](#iteration-mode) section below; do not run the filing-mode phases.
+- **Filing mode** — otherwise, treat the input as a design note path or infer one. Continue with the filing-mode phases below.
+
+### Filing mode: parse invocation
 
 - **Note path** (positional or inferred). If not specified, default to *the most recently modified* file in `docs/design-notes/` whose filename state token is `TODO`, `WIP`, or `REVIEW`. If multiple match, ask in Phase 2.
 - Optional flags: `--team`, `--project` (override note-derived routing).
@@ -202,6 +209,64 @@ Print:
 - Any failures
 - **Suggested commit message** following the repo's convention from `CLAUDE.md` (e.g., `chore(notes): file tickets from {slug} [ai:claude]`). **Do not commit** — git is HITL.
 
+## Iteration mode
+
+Entered when Phase 0 detects a Linear URL or issue ID. The filing-mode phases (1–3) are skipped entirely.
+
+### Load the issue
+
+Fetch in parallel:
+- `get_issue` — title, description, status, labels, priority
+- `list_comments` — full comment thread, ordered by `createdAt`
+
+Print a compact header so the user can confirm you're looking at the right thing:
+
+```
+Iterating on: VID-123 — {title}
+Status: {status} | Priority: {priority}
+{N} comments
+```
+
+### Understand the intent
+
+Read the user's prompt. Classify what they're asking for:
+
+- **Analytical** — "roast this", "what's missing", "does this make sense", "what questions should we answer first" → produce analysis in chat, then offer to post it as a comment
+- **Additive** — "add context about X", "note that we've decided Y" → draft a comment with the new context
+- **Refinement** — "sharpen the description", "the title is off" → propose a new title and/or description (keep it minimal — anchor principle applies)
+- **Mixed** — any combination of the above
+
+For mixed intents, address all of them in a single pass rather than asking for clarification upfront.
+
+### Draft the response
+
+Produce one or both of:
+
+1. **Comment draft** — the primary output in almost all cases. Write it as you would a thoughtful comment from a collaborator: direct, specific, actionable. Scope crystallization, analysis, questions, and context all belong here.
+2. **Anchor update** — only if the intent is explicitly to fix the title or description. Draft the new title and/or description. Keep to 2–4 sentences. Do not migrate comment-appropriate content into the description.
+
+Print both drafts in chat before asking for confirmation. Make it easy to scan.
+
+### Confirm and write
+
+Issue one `AskUserQuestion` with:
+- **Always:** "Post this comment?" — **Yes** / **Edit first** / **Skip**
+- **Only if an anchor update was drafted:** "Apply the title/description update?" — **Yes** / **Edit first** / **Skip**
+
+Both questions can be batched into a single `AskUserQuestion` call.
+
+On "Edit first": ask what to change, revise, re-present, confirm again.
+
+On approval, write in this order:
+1. `save_issue` for any title/description changes (only if confirmed)
+2. `save_comment` for the comment (only if confirmed)
+
+### Summary
+
+Print:
+- What was posted/updated and the issue URL
+- If nothing was written (user skipped both): note that and stop cleanly
+
 ## Anti-patterns
 
 - **Don't run on `DONE`/`SUPERSEDED`/`CANCELED`/`DEPRECATED` notes** or anything in `ARCHIVE/`. Historical notes are read-only.
@@ -216,6 +281,9 @@ Print:
 - **Don't infer parallel-safety from nothing.** If the note doesn't mention file scope or parallelism, leave parallel-safety unset. Don't fabricate predictions.
 - **Don't bundle unrelated action items into a single ticket.** One action item = one ticket. If items are tightly coupled, the note should reflect that and the skill can model them as parent/sub-tasks — but only if the note is structured that way.
 - **Don't over-fill descriptions.** A description is a minimal anchor — 2–4 sentences max. Do not copy prose, reasoning, or context from the design note into it. The backlink to the note is the bridge; if extra context is needed, post it as a comment after creation. Stuffing descriptions creates maintenance debt and obscures the signal.
+- **Don't default to description updates in iteration mode.** The user's intent is almost always to add a comment. Only propose a title/description change when the prompt explicitly targets the anchor (e.g. "the title is wrong", "rewrite the description"). When in doubt, put it in a comment.
+- **Don't run filing-mode phases in iteration mode.** If a Linear URL or issue ID was detected, skip straight to the iteration phase. Do not look for design notes, parse action items, or propose ticket creation.
+- **Don't silently rewrite comment history.** The skill can only add new comments via `save_comment`. It cannot edit or delete existing comments. If a prior comment is wrong, post a follow-up — don't attempt to alter the record.
 - **Don't ask more than one round of clarification** (the "Exclude some" follow-up is the only permitted second question). If something surfaces during creation that should have been asked, note it in the summary and stop.
 - **Don't follow URLs unbounded.** Use `WebFetch` only to enrich descriptions for URLs *already referenced in the note*, not to search the web. This skill is deterministic; research belongs in `designnote`.
 


### PR DESCRIPTION
## Summary
- Add iteration mode: `/linearissue <URL-or-ID> <prompt>` reads an existing Linear issue + its comments and responds via a drafted comment (primary) and/or a minimal title/description update (secondary, exception only)
- Embed anchor philosophy across both modes: issue descriptions are minimal anchors (2–4 sentences max), scope crystallization happens through comments
- Update filing mode (note → issues) to produce thin descriptions with a backlink rather than dumping design note prose into the ticket body

## Test plan
- [ ] `/linearissue VID-123 roast the scope` → enters iteration mode, drafts a comment, confirm gate works
- [ ] `/linearissue https://linear.app/... add context about X` → same flow
- [ ] `/linearissue docs/design-notes/some-note.md` → still enters filing mode correctly
- [ ] New tickets filed from a note have short descriptions (not context dumps)

> Stacked on top of `vidbina/vid-598-setup-gh-actions-pipeline`. Rebase onto main after #30 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)