### PR TITLE
Add /pr skill for creating pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  ci:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: cachix/install-nix-action@v31
+
+      - uses: nix-community/cache-nix-action@v6
+        with:
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-
+          gc-max-store-size-macos: 4000000000
+
+      - name: CI
+        run: nix develop --command make ci

--- a/README.org
+++ b/README.org
@@ -3437,6 +3437,7 @@ https://developpaper.com/complete-guide-to-getting-started-with-coc-nvim/
       <<nvim-packages>>
     ];
     vimdiffAlias = true;
+    withPython3 = false; # disable Python bundled into nvim
     withRuby = true;
     extraConfig = ''
       <<neovim-config>>

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -1,0 +1,25 @@
+{
+  "permissions": {
+    "allow": [
+      "Glob",
+      "Grep",
+      "Read",
+      "Bash(gh pr list*)",
+      "Bash(gh pr view*)",
+      "Bash(gh pr checks*)",
+      "Bash(gh pr status*)",
+      "Bash(gh pr diff*)",
+      "Bash(gh run list*)",
+      "Bash(gh run view*)",
+      "Bash(gh run download*)",
+      "Bash(gh issue list*)",
+      "Bash(gh issue view*)",
+      "Bash(gh issue status*)",
+      "Bash(gh repo view*)",
+      "Bash(gh repo list*)",
+      "Bash(gh release list*)",
+      "Bash(gh release view*)",
+      "Bash(gh api*)"
+    ]
+  }
+}

--- a/claude/skills/linearissue/SKILL.md
+++ b/claude/skills/linearissue/SKILL.md
@@ -15,6 +15,8 @@ The defining design principles of this skill are:
 > **Confirm in chat, not via files.** The skill prints proposed tickets in the conversation, confirms with one `AskUserQuestion`, and creates on approval. One invocation, one session.
 >
 > **Idempotent re-runs.** A note that's already been linearized has inline `Linear: LIN-NNN` annotations. The skill detects them and updates instead of duplicating.
+>
+> **Issues are minimal anchors; comments carry the thinking.** A ticket's title and description are a stable, concise anchor — what the work is, nothing more. Scope crystallization (additions, reductions, pushback, context, reasoning) happens through comments, which are immutable and preserve the history of thinking. Keep descriptions short and pragmatic. Never use them as a context dump from the design note — the backlink to the note is enough. This principle applies in both filing mode and iteration mode.
 
 ## How this fits the broader workflow
 
@@ -170,7 +172,7 @@ If the user bails, stop. Print nothing further.
 For each confirmed ticket:
 
 1. **Existing detection.** If the note's source-anchor area already has an inline `Linear: LIN-NNN` annotation, or if a Linear search by source anchor URL in the description footer finds an existing ticket, treat as **update**. Otherwise **create**.
-2. **Create:** call `save_issue` with team, project, title, description (including the source-anchor footer), priority, parent (if dependency-hinted as a sub-task — but default to flat unless the note structure clearly implies sub-tasking).
+2. **Create:** call `save_issue` with team, project, title, description (including the source-anchor footer), priority, parent (if dependency-hinted as a sub-task — but default to flat unless the note structure clearly implies sub-tasking). Keep the description to 2–4 sentences maximum: one sentence on what the work is, one sentence on why it matters (if not obvious), and the source-anchor backlink. Do not copy prose, context, or reasoning from the design note into the description — the backlink is the bridge. If there is important context that should accompany the ticket, post it as a comment after creation instead.
 3. **Update:** call `save_issue` with `id` set to the existing `LIN-NNN`, updating only fields that have meaningfully changed (description content, priority). Don't touch state, assignee, or labels unless explicitly indicated.
 4. **Capture** the returned ticket ID and URL.
 
@@ -213,6 +215,7 @@ Print:
 - **Don't interpret non-canonical sections creatively.** Only known sections and explicit `→ ticket` markers count. If a note has work in a non-canonical section, ask in Phase 3.
 - **Don't infer parallel-safety from nothing.** If the note doesn't mention file scope or parallelism, leave parallel-safety unset. Don't fabricate predictions.
 - **Don't bundle unrelated action items into a single ticket.** One action item = one ticket. If items are tightly coupled, the note should reflect that and the skill can model them as parent/sub-tasks — but only if the note is structured that way.
+- **Don't over-fill descriptions.** A description is a minimal anchor — 2–4 sentences max. Do not copy prose, reasoning, or context from the design note into it. The backlink to the note is the bridge; if extra context is needed, post it as a comment after creation. Stuffing descriptions creates maintenance debt and obscures the signal.
 - **Don't ask more than one round of clarification** (the "Exclude some" follow-up is the only permitted second question). If something surfaces during creation that should have been asked, note it in the summary and stop.
 - **Don't follow URLs unbounded.** Use `WebFetch` only to enrich descriptions for URLs *already referenced in the note*, not to search the web. This skill is deterministic; research belongs in `designnote`.
 

--- a/claude/skills/linearissue/SKILL.md
+++ b/claude/skills/linearissue/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: linearissue
-description: "Use this skill when the user asks you to turn a design note's action items into Linear issues — filing tickets from a note, linearizing the todos in a note, creating Linear issues from pending work in a design note, or shipping a note's action items to Linear for execution. Trigger for prompts like 'file tickets from this note', 'linearize X', 'create Linear issues for the action items in X', 'turn this note into tickets', 'ship this to Linear', 'file these TODOs from the design note', 'make tickets from X', 'linearissue this note', 'create issues from X.md'. Also trigger when the user invokes `/linearissue`. The skill reads a specific design note (or the most recent TODO/WIP note if not specified), parses its action items from canonical sections (## Action items, ## Next Action, ## Trigger Points, and inline checklists), prints a proposed-tickets summary in chat, confirms via AskUserQuestion, then creates the Linear issues and appends bidirectional cross-references back into the note. It refuses to run on DONE, SUPERSEDED, CANCELED, DEPRECATED notes, or anything in `ARCHIVE/`. Do NOT trigger for ad-hoc ticket creation not derived from a note (use the Linear MCP directly), for updating existing tickets in arbitrary ways (use the Linear MCP directly), for creating Linear documents (that's the designnote skill's strategy-routing path), for filing tickets from `docs/decisions/` ADRs (decisions are made; they don't spawn tickets), or for any operation that would also commit to git."
+description: "Use this skill when the user asks you to turn a design note's action items into Linear issues, OR when the user wants to iterate on an existing Linear issue. Filing mode triggers: 'file tickets from this note', 'linearize X', 'create Linear issues for the action items in X', 'turn this note into tickets', 'ship this to Linear', 'file these TODOs from the design note', 'make tickets from X', 'linearissue this note', 'create issues from X.md'. Iteration mode triggers: user passes a Linear issue URL (e.g. https://linear.app/...) or issue ID (e.g. VID-123) with a follow-on prompt like 'help me refine this', 'roast this scope', 'add context about X', 'what questions should we answer first', 'sharpen the description', or any request to think about, improve, or comment on an existing issue. Also trigger when the user invokes `/linearissue`. Do NOT trigger for creating Linear documents (that's the designnote skill's strategy-routing path), for filing tickets from `docs/decisions/` ADRs (decisions are made; they don't spawn tickets), or for any operation that would also commit to git."
 allowed-tools: Glob Grep Read Edit WebFetch AskUserQuestion mcp__claude_ai_Linear__list_issues mcp__claude_ai_Linear__get_issue mcp__claude_ai_Linear__save_issue mcp__claude_ai_Linear__list_comments mcp__claude_ai_Linear__save_comment mcp__claude_ai_Linear__list_teams mcp__claude_ai_Linear__get_team mcp__claude_ai_Linear__list_projects mcp__claude_ai_Linear__get_project mcp__claude_ai_Linear__list_issue_statuses mcp__claude_ai_Linear__list_issue_labels
 ---
 
@@ -56,7 +56,14 @@ The skill does not declare `Write` — it never creates new files. It only edits
 
 ## Phase 0 — Preflight
 
-### Parse invocation
+### Parse invocation and detect mode
+
+Examine the first argument (or the full prompt if no explicit argument):
+
+- **Iteration mode** — if the input contains a Linear issue URL (`https://linear.app/...`) or a bare issue identifier matching the pattern `[A-Z]+-\d+` (e.g. `VID-123`, `Z-419`), enter **iteration mode**. Capture the issue ID and the rest of the prompt as the user's intent. Skip to the [Iteration mode](#iteration-mode) section below; do not run the filing-mode phases.
+- **Filing mode** — otherwise, treat the input as a design note path or infer one. Continue with the filing-mode phases below.
+
+### Filing mode: parse invocation
 
 - **Note path** (positional or inferred). If not specified, default to *the most recently modified* file in `docs/design-notes/` whose filename state token is `TODO`, `WIP`, or `REVIEW`. If multiple match, ask in Phase 2.
 - Optional flags: `--team`, `--project` (override note-derived routing).
@@ -202,6 +209,64 @@ Print:
 - Any failures
 - **Suggested commit message** following the repo's convention from `CLAUDE.md` (e.g., `chore(notes): file tickets from {slug} [ai:claude]`). **Do not commit** — git is HITL.
 
+## Iteration mode
+
+Entered when Phase 0 detects a Linear URL or issue ID. The filing-mode phases (1–3) are skipped entirely.
+
+### Load the issue
+
+Fetch in parallel:
+- `get_issue` — title, description, status, labels, priority
+- `list_comments` — full comment thread, ordered by `createdAt`
+
+Print a compact header so the user can confirm you're looking at the right thing:
+
+```
+Iterating on: VID-123 — {title}
+Status: {status} | Priority: {priority}
+{N} comments
+```
+
+### Understand the intent
+
+Read the user's prompt. Classify what they're asking for:
+
+- **Analytical** — "roast this", "what's missing", "does this make sense", "what questions should we answer first" → produce analysis in chat, then offer to post it as a comment
+- **Additive** — "add context about X", "note that we've decided Y" → draft a comment with the new context
+- **Refinement** — "sharpen the description", "the title is off" → propose a new title and/or description (keep it minimal — anchor principle applies)
+- **Mixed** — any combination of the above
+
+For mixed intents, address all of them in a single pass rather than asking for clarification upfront.
+
+### Draft the response
+
+Produce one or both of:
+
+1. **Comment draft** — the primary output in almost all cases. Write it as you would a thoughtful comment from a collaborator: direct, specific, actionable. Scope crystallization, analysis, questions, and context all belong here.
+2. **Anchor update** — only if the intent is explicitly to fix the title or description. Draft the new title and/or description. Keep to 2–4 sentences. Do not migrate comment-appropriate content into the description.
+
+Print both drafts in chat before asking for confirmation. Make it easy to scan.
+
+### Confirm and write
+
+Issue one `AskUserQuestion` with:
+- **Always:** "Post this comment?" — **Yes** / **Edit first** / **Skip**
+- **Only if an anchor update was drafted:** "Apply the title/description update?" — **Yes** / **Edit first** / **Skip**
+
+Both questions can be batched into a single `AskUserQuestion` call.
+
+On "Edit first": ask what to change, revise, re-present, confirm again.
+
+On approval, write in this order:
+1. `save_issue` for any title/description changes (only if confirmed)
+2. `save_comment` for the comment (only if confirmed)
+
+### Summary
+
+Print:
+- What was posted/updated and the issue URL
+- If nothing was written (user skipped both): note that and stop cleanly
+
 ## Anti-patterns
 
 - **Don't run on `DONE`/`SUPERSEDED`/`CANCELED`/`DEPRECATED` notes** or anything in `ARCHIVE/`. Historical notes are read-only.
@@ -216,6 +281,9 @@ Print:
 - **Don't infer parallel-safety from nothing.** If the note doesn't mention file scope or parallelism, leave parallel-safety unset. Don't fabricate predictions.
 - **Don't bundle unrelated action items into a single ticket.** One action item = one ticket. If items are tightly coupled, the note should reflect that and the skill can model them as parent/sub-tasks — but only if the note is structured that way.
 - **Don't over-fill descriptions.** A description is a minimal anchor — 2–4 sentences max. Do not copy prose, reasoning, or context from the design note into it. The backlink to the note is the bridge; if extra context is needed, post it as a comment after creation. Stuffing descriptions creates maintenance debt and obscures the signal.
+- **Don't default to description updates in iteration mode.** The user's intent is almost always to add a comment. Only propose a title/description change when the prompt explicitly targets the anchor (e.g. "the title is wrong", "rewrite the description"). When in doubt, put it in a comment.
+- **Don't run filing-mode phases in iteration mode.** If a Linear URL or issue ID was detected, skip straight to the iteration phase. Do not look for design notes, parse action items, or propose ticket creation.
+- **Don't silently rewrite comment history.** The skill can only add new comments via `save_comment`. It cannot edit or delete existing comments. If a prior comment is wrong, post a follow-up — don't attempt to alter the record.
 - **Don't ask more than one round of clarification** (the "Exclude some" follow-up is the only permitted second question). If something surfaces during creation that should have been asked, note it in the summary and stop.
 - **Don't follow URLs unbounded.** Use `WebFetch` only to enrich descriptions for URLs *already referenced in the note*, not to search the web. This skill is deterministic; research belongs in `designnote`.
 

--- a/claude/skills/pairprog/SKILL.md
+++ b/claude/skills/pairprog/SKILL.md
@@ -1,0 +1,359 @@
+---
+name: pairprog
+description: "Use this skill when the user wants to pair-program on a ticket — working through a Linear issue collaboratively with the AI driving and the human navigating. Trigger for prompts like 'let's work on this ticket', 'pair on LIN-123', 'pairprog', 'let's tackle this branch', 'work on the current branch', 'pick up LIN-123', 'start working on this', 'let's pair on this'. Also trigger when the user invokes `/pairprog`. The skill reads the current branch (or a specified ticket/branch), looks up the Linear ticket, explores the codebase for context, identifies unknowns and feasibility risks, asks the human navigator for direction on key decisions, then executes the work in atomic steps with frequent HITL checkpoints. It uses concurrent subagents to parallelize independent exploration and implementation work. It comments assessments, spike findings, and plans back to the Linear ticket so context survives across sessions. In default mode, the human commits after reviewing each atomic change. In yolo mode, the skill auto-commits atomically and gates at PR creation. This is NOT a walk-away skill. It is an interactive pairing session where the human stays engaged as navigator. Do NOT trigger for autonomous background work (use designnote or direct implementation), for ticket creation (use linearissue), for research without implementation (use qsearch), or for commit message drafting (use commitmsg)."
+allowed-tools: Bash Glob Grep Read Write Edit Task AskUserQuestion WebFetch mcp__claude_ai_Linear__get_issue mcp__claude_ai_Linear__list_issues mcp__claude_ai_Linear__list_comments mcp__claude_ai_Linear__save_comment mcp__claude_ai_Linear__list_teams mcp__claude_ai_Linear__get_team mcp__claude_ai_Linear__list_projects mcp__claude_ai_Linear__get_project mcp__claude_ai_Linear__list_issue_statuses mcp__claude_ai_Linear__list_issue_labels
+---
+
+# pairprog
+
+Pair-program on a ticket. **You drive, the human navigates.**
+
+This skill is the opposite of walk-away. The human is at the keyboard, engaged, steering. You write the code, explain your thinking, surface decisions, and check in frequently. The rhythm is: explore → plan → check in → implement a step → check in → repeat.
+
+The defining design principles are:
+
+> **Driver/navigator dynamic.** You drive (write code, run exploration, propose changes). The human navigates (steers direction, makes judgment calls, approves changes, commits). Neither works alone.
+>
+> **Derisk first.** Before writing production code, identify what's uncertain and spike on it. Feasibility unknowns resolved early prevent wasted work late.
+>
+> **Atomic steps with checkpoints.** Each change is small enough to review in one pass. The human sees the change, gives feedback, and commits when satisfied. No large PRs assembled silently.
+>
+> **Parallel where possible.** Use subagents for independent exploration and implementation tasks. Don't serialize work that can run concurrently. But always reconvene with the navigator before acting on findings.
+>
+> **Comment everything back to the ticket.** Assessments, spike findings, plans, and step completions are posted as Linear comments. This means a cancelled session can be picked up later — the ticket carries the full context.
+
+## Commit modes
+
+The skill supports two commit modes. Default is **checkpoint mode**. The navigator can switch to **yolo mode** at any time during the session.
+
+- **Checkpoint mode (default):** The skill presents each atomic change, the navigator reviews it, and the navigator commits manually. The skill never runs git write commands.
+- **Yolo mode:** The skill auto-commits each atomic step using the `commitmsg` skill for message generation, and gates at PR creation. The navigator can switch back to checkpoint mode at any time.
+
+At the start of the session, if the skill detects this is a fresh ticket with no prior work, ask:
+
+> "Checkpoint mode (you review and commit each step) or yolo mode (I auto-commit, you review at PR time)?"
+
+If prior work exists on the branch, default to checkpoint without asking (the navigator is resuming deliberate work).
+
+## Phase 0 — Pick up the ticket
+
+### Identify the work
+
+Determine what ticket to work on, in this order:
+
+1. **Explicit argument** — if the user passed a ticket ID (`LIN-123`, `Z-123`) or branch name, use that.
+2. **Current branch** — run `git branch --show-current`. If the branch name contains a ticket identifier (e.g., `vidbina/z-123-some-description`), extract it.
+3. **Ask** — if neither yields a ticket, ask the user what to work on.
+
+### Check out the branch
+
+If the ticket has a git branch name (from the Linear issue's `branchName` field or inferred from the ticket ID), and that branch is not currently checked out:
+
+- Run `git fetch` to ensure the branch is available locally.
+- Run `git checkout {branch}` to switch to it.
+- If the branch doesn't exist yet, ask the navigator: "No branch for this ticket yet. Create `{suggested-branch-name}` from `main`?" On approval, create and check out.
+
+If the user passed a branch name directly rather than a ticket ID, check it out if not already on it.
+
+### Load context (parallel)
+
+Once the ticket ID is known and the branch is checked out, fetch all of these in parallel:
+
+- **Linear ticket:** `get_issue` with the ticket ID. Capture title, description, state, priority, labels, project, parent issue.
+- **Linear comments:** `list_comments` — read existing comments. If a previous pairprog session left assessment/plan/spike comments, note them. This is the resumption path.
+- **Branch state:** `git log --oneline -10`, `git status`, `git diff main...HEAD` (or appropriate base branch) to understand what's already been done on this branch.
+- **Codebase orientation:** Use `Task` with `subagent_type: Explore` to understand the areas of the codebase most likely relevant to the ticket (based on ticket title/description keywords).
+- **Repo conventions:** Read `CLAUDE.md` / `AGENTS.md` / `CONTRIBUTING.md` at the repo root for development workflow, testing, and quality requirements.
+
+### Present the ticket
+
+Print a compact summary:
+
+```
+Ticket: Z-123 — Add OAuth2 support for Google login
+Status: In Progress | Priority: High | Project: Auth
+Branch: vidbina/z-123-add-oauth2-google-login (3 commits ahead of main)
+
+Description:
+> [Quoted ticket description, trimmed to essentials]
+
+Prior session context (from comments):
+> [If previous pairprog comments exist, summarize what was assessed/planned/completed]
+
+Branch work so far:
+> [Summary of existing commits on this branch, if any]
+```
+
+If prior pairprog comments indicate the session was interrupted, note what was completed and what remains.
+
+## Phase 1 — Assess and derisk
+
+### Identify unknowns
+
+Read the ticket and existing branch work. Categorize what remains:
+
+- **Clear and ready** — requirements are unambiguous, implementation path is known, can start immediately.
+- **Unclear requirements** — the ticket is vague or contradictory on what exactly to build. Needs navigator input.
+- **Feasibility unknowns** — "can we even do X?" questions. These need a spike before committing to an approach.
+- **Dependency unknowns** — blocked by something external (API availability, another PR, a library feature). Needs investigation.
+
+### Comment the assessment to Linear
+
+Post a single comment to the ticket with the full assessment using `save_comment`:
+
+```markdown
+**Assessment** (pairprog)
+
+**Clear and ready:**
+- Add Google OAuth callback endpoint
+- Store refresh tokens in existing session table
+
+**Unclear — need navigator input:**
+- Token expiry handling — ticket says "handle gracefully" but doesn't specify
+- Scope of Google permissions — email only, or also profile?
+
+**Feasibility unknowns — spiking:**
+- Google OAuth library compatibility with our Node version
+- Session table schema — can we store tokens without a migration?
+
+**Blocked:**
+- (none)
+```
+
+### Spike on feasibility (parallel)
+
+For each feasibility unknown, spawn a `Task` subagent to investigate:
+
+- Read relevant source code, docs, or external references
+- Try small proof-of-concept explorations (read-only or in scratch space)
+- Return a structured answer: feasible / not feasible / feasible with caveats
+
+Subagents are read-only investigators. They don't write production code.
+
+**Wait for all spikes to complete before commenting.** Don't post "starting spike" comments — post one consolidated findings comment per spike after the subagent returns:
+
+```markdown
+**Spike: Google OAuth library compatibility** (pairprog)
+
+**Verdict:** Feasible ✓
+
+`@googleapis/google-auth-library` v9.x supports Node 18+. Tested import resolution
+against our `tsconfig.json` paths — no conflicts. The `OAuth2Client` class exposes
+`getToken()` and `refreshToken()` which map directly to our needs.
+
+Relevant code: `src/config/auth.ts` already has a provider pattern we can extend.
+```
+
+### Check in with the navigator
+
+Present findings to the human:
+
+```
+Ready to implement:
+ 1. Add Google OAuth callback endpoint
+ 2. Store refresh tokens in existing session table
+
+Need your input:
+ 3. Token expiry handling — ticket says "handle gracefully" but doesn't specify.
+    Options: (a) silent refresh, (b) redirect to login, (c) both with fallback
+ 4. Scope of Google permissions — email only, or also profile?
+
+Spiked and resolved:
+ 5. Google OAuth library — compatible ✓ (see ticket comment)
+ 6. Session table schema — can use metadata JSONB column ✓ (see ticket comment)
+
+Blocked:
+ (none)
+```
+
+Use `AskUserQuestion` for the items that need input. In pair programming, asking questions as they arise is expected. Batch questions that are ready at the same time rather than asking them one by one.
+
+## Phase 2 — Plan the work
+
+### Break into atomic steps
+
+Each step should be:
+
+- **Reviewable in isolation** — a human can read the diff and understand the intent
+- **Testable** — either via existing tests, a new test, or manual verification
+- **Committable** — it doesn't leave the codebase in a broken state
+
+### Identify parallelism
+
+Mark which steps are independent and can be worked on by concurrent subagents. Typical parallel opportunities:
+
+- Tests for different modules
+- Implementation of independent functions/components
+- Documentation updates alongside code changes
+
+### Present the plan
+
+```
+Plan for Z-123 — Add OAuth2 support for Google login
+
+Step 1: Add Google OAuth callback route
+  Files: src/routes/auth.ts, src/config/oauth.ts (new)
+  Test: src/routes/__tests__/auth.test.ts
+
+Step 2: Token storage in session metadata    ← parallel with Step 3
+  Files: src/services/session.ts
+  Test: src/services/__tests__/session.test.ts
+
+Step 3: Silent token refresh middleware       ← parallel with Step 2
+  Files: src/middleware/auth.ts
+  Test: src/middleware/__tests__/auth.test.ts
+
+Step 4: Update login UI with Google button   ← after Steps 1-3
+  Files: src/components/LoginForm.tsx
+  Test: manual verification
+
+Ready to start?
+```
+
+Wait for the navigator's approval or adjustment before proceeding.
+
+### Comment the plan to Linear
+
+After the navigator approves (or adjusts) the plan, post it as a comment:
+
+```markdown
+**Plan** (pairprog)
+
+- [ ] Step 1: Add Google OAuth callback route
+- [ ] Step 2: Token storage in session metadata (parallel with 3)
+- [ ] Step 3: Silent token refresh middleware (parallel with 2)
+- [ ] Step 4: Update login UI with Google button (after 1-3)
+```
+
+This checklist serves as the resumption point if the session is interrupted.
+
+## Phase 3 — Execute
+
+### Work through the plan
+
+For each step:
+
+1. **Announce** what you're about to do. "Starting Step 1 — adding the OAuth callback route."
+2. **Implement** the change. Use `Edit` / `Write` for code changes.
+3. **Run quality checks** if the repo has them (lint, typecheck, test). Use `Bash` for this. If a check fails, fix it before presenting.
+4. **Present the change.** Print a concise summary of what changed and why. Don't dump the full diff — describe the intent and highlight non-obvious decisions.
+5. **Checkpoint.**
+   - **Checkpoint mode:** Pause for the navigator's feedback. If the navigator says "looks good," they commit. If they want changes, iterate.
+   - **Yolo mode:** Invoke the `commitmsg` skill's methodology (read repo convention, draft message) and auto-commit. Print the commit hash and message. Continue to the next step.
+
+### Comment step completions to Linear
+
+After each step is committed (by the navigator in checkpoint mode, or auto-committed in yolo mode), post a brief comment:
+
+```markdown
+**Step 1 complete** (pairprog)
+
+Added Google OAuth callback route in `src/routes/auth.ts` and `src/config/oauth.ts`.
+Test added in `src/routes/__tests__/auth.test.ts` — passing.
+
+Commit: `a1b2c3d`
+```
+
+### Parallel execution
+
+When the plan has independent steps, use `Task` subagents to work on them concurrently:
+
+- Each subagent receives the full plan context and its assigned step
+- Each subagent writes its changes and runs its tests
+- When both complete, present the combined results to the navigator
+- Each step is committed separately (atomic commits) — in checkpoint mode the navigator reviews each; in yolo mode both auto-commit
+
+After parallel subagents complete, post one combined comment to keep the thread focused rather than interleaving.
+
+### Adapting mid-session
+
+Pair programming is fluid. The plan from Phase 2 is a starting point, not a contract. If the navigator wants to:
+
+- Reprioritize steps → adjust the order
+- Add a step → insert it
+- Skip a step → skip it
+- Change approach entirely → re-plan from Phase 2
+
+Accommodate without friction. The navigator steers.
+
+When mid-session adaptation happens, comment the change to Linear with a recognizable marker:
+
+```markdown
+🔀 **Plan adjusted** (pairprog)
+
+Step 3 (Silent token refresh middleware) replaced with:
+Step 3a: Explicit re-login flow on token expiry
+
+Reason: Navigator decided silent refresh adds complexity without clear UX benefit.
+```
+
+Use these emojis for mid-session events:
+- 🔀 — plan change (step reordered, replaced, or approach changed)
+- ⏭️ — step skipped
+- ➕ — step added
+- 🚧 — blocker discovered mid-implementation
+- ⚠️ — conflict between plan and reality (code doesn't behave as expected, API doesn't work as documented, etc.)
+
+## Phase 4 — Wrap up
+
+When all steps are implemented (or the session ends naturally):
+
+### Summary
+
+Print what was accomplished:
+
+- What was implemented, what tests were added/updated
+- What's left (if anything) and whether it needs a follow-up session or more design
+- Any blockers or open questions that surfaced during implementation
+
+### Commit threshold
+
+If there are uncommitted changes (checkpoint mode only):
+
+- Use the `commitmsg` skill to generate messages for any uncommitted work
+- If multiple logical changes are uncommitted, suggest breaking them into separate commits and provide a message for each
+- The navigator decides what to stage and commit
+
+### PR creation
+
+If the branch looks complete relative to the ticket scope:
+
+1. **Draft the PR pitch in chat.** Show the proposed title, body (summary of changes, test plan), and target branch. Format it so the navigator can review before anything is created.
+2. **Ask:** "Ready to create this PR via `gh`?" with options: **Yes, create it** / **Edit first** / **Not yet — more work needed**
+3. On approval, create the PR using `gh pr create` via `Bash`.
+4. On "Edit first," let the navigator adjust the pitch, then create.
+5. On "Not yet," skip. The navigator will create it when ready.
+
+### Comment wrap-up to Linear
+
+Post a final session summary comment:
+
+```markdown
+**Session complete** (pairprog)
+
+**Completed:**
+- [x] Step 1: OAuth callback route
+- [x] Step 2: Token storage
+- [x] Step 3a: Explicit re-login flow
+- [x] Step 4: Login UI with Google button
+
+**Remaining:**
+- (none — PR created: #47)
+
+**Commits:** a1b2c3d, d4e5f6a, b7c8d9e, f0a1b2c
+```
+
+## Anti-patterns
+
+- **Don't work silently for long stretches.** This is pairing, not autonomous mode. Check in after each atomic step. If exploration takes a while, print progress notes.
+- **Don't commit in checkpoint mode.** All git write operations are HITL unless the navigator explicitly switched to yolo mode.
+- **Don't skip the derisk phase.** Feasibility unknowns caught early save time. Don't jump to implementation because "it's probably fine."
+- **Don't serialize parallelizable work.** If two steps are independent, use subagents. The navigator's time is valuable.
+- **Don't make large changes without checkpoints.** If a step turns out bigger than expected, break it down further and checkpoint mid-step.
+- **Don't assume the plan is fixed.** The navigator can redirect at any checkpoint. Accommodate without pushback.
+- **Don't ask trivial questions.** The navigator is engaged but shouldn't be pestered. Ask about direction and judgment calls, not about syntax or obvious implementation details.
+- **Don't ignore the repo's quality gates.** If the repo has lint/test/typecheck commands in CLAUDE.md or README, run them before presenting a change.
+- **Don't touch unrelated code.** Stay within the scope of the ticket. If you notice unrelated issues, mention them verbally — don't fix them unless the navigator asks.
+- **Don't post "starting spike" comments.** Wait for the spike to complete, then post findings. One comment per spike, not a running log.
+- **Don't interleave parallel step comments.** When subagents work concurrently, post one combined comment after both complete.
+- **Don't create PRs without pitching first.** Always show the proposed PR content in chat and get explicit approval before running `gh pr create`.

--- a/claude/skills/pairprog/SKILL.md
+++ b/claude/skills/pairprog/SKILL.md
@@ -320,7 +320,7 @@ If the branch looks complete relative to the ticket scope:
 
 1. **Draft the PR pitch in chat.** Show the proposed title, body (summary of changes, test plan), and target branch. Format it so the navigator can review before anything is created.
 2. **Ask:** "Ready to create this PR via `gh`?" with options: **Yes, create it** / **Edit first** / **Not yet — more work needed**
-3. On approval, create the PR using `gh pr create` via `Bash`.
+3. On approval, push the branch (`git push -u origin {branch}`) then create the PR using `gh pr create` via `Bash`.
 4. On "Edit first," let the navigator adjust the pitch, then create.
 5. On "Not yet," skip. The navigator will create it when ready.
 

--- a/claude/skills/pairprog/SKILL.md
+++ b/claude/skills/pairprog/SKILL.md
@@ -279,7 +279,7 @@ Accommodate without friction. The navigator steers.
 When mid-session adaptation happens, comment the change to Linear with a recognizable marker:
 
 ```markdown
-🔀 **Plan adjusted** (pairprog)
+🚨 **Plan adjusted** (pairprog)
 
 Step 3 (Silent token refresh middleware) replaced with:
 Step 3a: Explicit re-login flow on token expiry
@@ -288,9 +288,9 @@ Reason: Navigator decided silent refresh adds complexity without clear UX benefi
 ```
 
 Use these emojis for mid-session events:
-- 🔀 — plan change (step reordered, replaced, or approach changed)
+- 🚨 — plan change (step reordered, replaced, or approach changed)
 - ⏭️ — step skipped
-- ➕ — step added
+- 🌟 — step added
 - 🚧 — blocker discovered mid-implementation
 - ⚠️ — conflict between plan and reality (code doesn't behave as expected, API doesn't work as documented, etc.)
 

--- a/claude/skills/pr/SKILL.md
+++ b/claude/skills/pr/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: pr
+description: "Use this skill when the user wants to create a pull request for the current branch. Trigger for prompts like 'create a PR', 'open a PR', 'make a pull request', 'pr this', 'ship it', or when the user invokes `/pr`. Also invoked by other skills (/pairprog, /troubleshoot) at wrap-up. The skill detects the correct base branch automatically — if the current branch is stacked on another feature branch rather than main, it uses that branch as the base. It reads the Linear ticket (if any) and recent commits to draft a title and body, pitches the draft in chat for the operator to review, and creates the PR via `gh pr create` on approval. DX-first: fast, good defaults, minimal ceremony. Do NOT trigger for reviewing existing PRs, for merging, or for anything other than creating a new PR."
+allowed-tools: Bash Glob Grep Read AskUserQuestion mcp__claude_ai_Linear__get_issue mcp__claude_ai_Linear__list_comments
+---
+
+# pr
+
+Create a pull request. **Fast, good defaults, operator confirms before anything is created.**
+
+The defining design principles:
+
+> **DX-first.** Derive as much as possible automatically — base branch, title, body. The operator should need to type as little as possible.
+>
+> **Pitch before creating.** Always show the full draft in chat and get explicit approval. Never run `gh pr create` without confirmation.
+>
+> **Smart base for stacked PRs.** If the branch was cut from another feature branch (not main), use that branch as the base. Merging a stacked PR into main loses the stack structure.
+
+## Phase 1 — Gather context
+
+Run in parallel:
+
+- **Branch:** `git branch --show-current`
+- **Commits on branch:** `git log --oneline main..HEAD` (or `git log --oneline HEAD ^origin/main` if on remote)
+- **Push state:** `git status -sb` — is the branch already pushed to origin?
+- **Remote default branch:** `gh repo view --json defaultBranchRef -q .defaultBranchRef.name` — don't hardcode `main`
+
+Extract a ticket ID from the branch name if present (e.g. `vidbina/vid-123-some-slug` → `VID-123`). If found, fetch the Linear issue (`get_issue`) for title and description.
+
+## Phase 2 — Detect base branch
+
+Find the correct base using this algorithm:
+
+```bash
+# All local branches that are ancestors of HEAD, ranked by closeness
+git for-each-ref --format='%(refname:short)' refs/heads/ \
+  | grep -v "$(git branch --show-current)" \
+  | while read b; do
+      if git merge-base --is-ancestor "$b" HEAD 2>/dev/null; then
+        count=$(git log --oneline "$b"..HEAD | wc -l | tr -d ' ')
+        echo "$count $b"
+      fi
+    done \
+  | sort -n \
+  | head -5
+```
+
+The branch with the **fewest commits between its tip and HEAD** is the most likely parent.
+
+**Decision rules:**
+- If the closest ancestor is the default branch (e.g. `main`) → normal PR, base = default branch.
+- If the closest ancestor is another feature branch → stacked PR, base = that feature branch. Flag this clearly in the pitch: "This looks like a stacked PR — base set to `<parent-branch>`."
+- If ambiguous (tie or no clear parent), default to the repo's default branch and note the ambiguity.
+
+## Phase 3 — Draft
+
+**Title:**
+1. Use the Linear ticket title if available.
+2. Otherwise, derive from the branch name slug (strip the owner prefix and ticket ID, humanize the remainder).
+3. Keep it under 72 characters.
+
+**Body:**
+```markdown
+## Summary
+<2-4 bullet points — what changed and why, derived from commits and ticket description>
+
+## Test plan
+<bullet checklist of how to verify the change>
+
+<Linear ticket link if available>
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+```
+
+Derive the summary from commit messages and the Linear ticket description. Derive the test plan from the nature of the changes (e.g. "run tests", "manually verify X flow", "check CI passes").
+
+## Phase 4 — Pitch in chat
+
+Print the full draft before doing anything:
+
+```
+PR draft
+
+Title:  <title>
+Base:   <base-branch>  [stacked ⚠] or [default branch]
+Branch: <current-branch>
+
+Body:
+---
+<body>
+---
+
+Create this PR? yes / edit / cancel
+```
+
+Use `AskUserQuestion` to get the response. Options:
+- **yes** → proceed to Phase 5
+- **edit** → the operator pastes corrections; apply them and re-pitch
+- **cancel** → stop, no PR created
+
+## Phase 5 — Create
+
+1. **Push if needed:** if the branch isn't on origin yet, run `git push -u origin <branch>`. Print the push result.
+2. **Create:** run `gh pr create --base <base> --title "<title>" --body "<body>"` via `Bash`.
+3. **Print the PR URL** returned by `gh`.
+
+Done. No further action — merging, labeling, and assignment are human operations.
+
+## Anti-patterns
+
+- **Don't hardcode `main` as base.** Always detect the default branch and check for stacking.
+- **Don't create the PR without pitching.** The operator must see and approve the draft.
+- **Don't fabricate the test plan.** Derive it from the diff or say "verify manually" — don't invent test steps that don't exist.
+- **Don't push without noting it.** If a push is needed, say so before running it.
+- **Don't ask more than one round of questions.** All clarification happens in the pitch → edit loop, not via separate `AskUserQuestion` calls before Phase 4.

--- a/claude/skills/troubleshoot/SKILL.md
+++ b/claude/skills/troubleshoot/SKILL.md
@@ -1,0 +1,217 @@
+---
+name: troubleshoot
+description: "Use this skill when the user wants to diagnose an error, investigate a failure, or root-cause a bug — without necessarily fixing it right away. Trigger for prompts like 'troubleshoot X', 'why is Y failing', 'debug this error', 'investigate LIN-123', 'figure out what's wrong with Z', 'look into this CI failure', 'root-cause this crash', or when the user invokes `/troubleshoot`. The skill is a walk-away investigator: it runs read-only commands, tees output to files, investigates in parallel via subagents, formulates a root-cause hypothesis, and confirms it with a minimal reproducible test — all with minimal interrupts so the operator can step away and return to a finished report. Findings are posted as Linear comments or design note updates depending on context. If a fix is needed after the diagnosis, the skill hands off to /pairprog. Do NOT trigger when the user wants to immediately implement a fix (use /pairprog), when pure web research suffices (use /qsearch), or when the issue is a design decision rather than a failure (use /designnote)."
+allowed-tools: Bash Glob Grep Read Task AskUserQuestion WebSearch WebFetch mcp__claude_ai_Linear__get_issue mcp__claude_ai_Linear__list_issues mcp__claude_ai_Linear__list_comments mcp__claude_ai_Linear__save_comment mcp__claude_ai_Linear__get_document mcp__claude_ai_Linear__list_documents mcp__claude_ai_Linear__list_teams mcp__claude_ai_Linear__get_team mcp__claude_ai_Linear__list_projects mcp__claude_ai_Linear__get_project
+---
+
+# troubleshoot
+
+Diagnose a failure. **You investigate autonomously; the human reviews findings.**
+
+This is the opposite of /pairprog. The operator may be away. You cover as much ground as possible uninterrupted, tee every command's output to a file, and return a clear root-cause report with a reproducible test. The human returns to findings, not questions.
+
+The defining design principles are:
+
+> **Walk-away investigation.** Minimize interrupts. Ask at most one up-front clarification batch, then run to completion. The operator should be able to kick this off, answer a handful of questions if needed, and come back to a finished diagnosis.
+>
+> **Tee everything to files.** Every command that produces non-trivial output is redirected to a file (`command > output/cmd-name.txt 2>&1`). This prevents context-window flooding, makes re-inspection cheap, and means the investigation survives a restart without re-running expensive commands.
+>
+> **Root cause, not symptoms.** A good diagnosis names the specific line of code, configuration value, dependency version, or environmental condition that caused the failure — not just "the test failed." Support the hypothesis with evidence.
+>
+> **Reproduce to confirm.** A hypothesis without a reproduction is a guess. Before reporting, write a minimal repro (a command, script, or test invocation) that demonstrates the failure. If you cannot reproduce it, say so explicitly and explain why.
+>
+> **Parallel investigation.** Use `Task` subagents for independent investigation threads. Don't serialize work that can run concurrently. Reconvene with consolidated findings before writing the report.
+>
+> **Comment findings back to the ticket.** Every investigation — even a partial one — gets commented to the associated Linear ticket or design note. A cancelled session carries forward.
+
+## Phase 0 — Identify the problem
+
+Determine what to investigate, in this order:
+
+1. **Explicit argument** — if the user passed a ticket ID, error message, file path, or description, use that as the starting point.
+2. **Current branch** — extract a ticket identifier from `git branch --show-current` (e.g. `vidbina/lin-123-...` → `LIN-123`).
+3. **Ask** — if neither yields a clear target, ask the user what to investigate.
+
+### Load context (parallel)
+
+Once the target is known, load in parallel:
+
+- **Linear ticket** (if applicable): `get_issue` — title, description, comments, labels, project.
+- **Recent comments**: `list_comments` — check for prior investigation notes or known constraints.
+- **Branch state**: `git log --oneline -10`, `git status`, `git diff main...HEAD --stat`.
+- **Error artifacts**: any log files, CI output files, or stack traces already present in the repo — glob for `*.log`, `*.txt` in common output directories, or paths the user mentioned.
+- **Repo orientation**: `Task` subagent to identify the areas of the codebase most relevant to the failure (based on the error message or ticket keywords).
+
+### Clarify once, up front
+
+Identify any inputs that would materially change the investigation path (environment, reproduction steps, constraints). Batch them into a **single** `AskUserQuestion` call. Keep it short. If the ticket or error is clear enough, skip this entirely.
+
+After answering (or if no questions are needed), the user can walk away.
+
+## Phase 1 — Investigate
+
+### Create an output directory
+
+```bash
+mkdir -p troubleshoot-output
+```
+
+All command output goes here. Never run a long command and discard its output — always tee:
+
+```bash
+some-command > troubleshoot-output/some-command.txt 2>&1
+```
+
+### Identify investigation threads
+
+Read the ticket / error and list the independent investigation threads. For example:
+- Thread A: Inspect the failing code path
+- Thread B: Check dependency versions and compatibility
+- Thread C: Review CI logs for environment differences
+- Thread D: Search for related issues or prior occurrences
+
+### Run threads in parallel
+
+Spawn one `Task` subagent per independent thread. Each subagent:
+- Runs read-only commands and tees output to `troubleshoot-output/`
+- Reads source code, config files, logs relevant to its thread
+- Returns a structured mini-report: **what was found**, **what was ruled out**, **remaining unknowns**
+
+Subagents are read-only investigators. They do not edit production code.
+
+### Permitted read-only operations
+
+- **Filesystem**: `ls`, `find`, `cat`, `head`, `tail`, `stat` — across project tree and system paths (for nix/system dep investigation)
+- **Git**: all read operations — `git log`, `git diff`, `git show`, `git blame`, `git stash list`, etc.
+- **Nix**: `nix eval`, `nix path-info`, `nix store ls`, `nix why-depends`, `nix flake show`, `nix flake metadata` — introspect the store and derivations
+- **Search**: `grep`, `ripgrep` — across project tree and system paths
+- **Web**: `WebSearch`, `WebFetch` — for error messages, library issues, known bugs, release notes
+- **GitHub / CI**: `gh run list`, `gh run view`, `gh run download` — read CI logs and artifact output
+
+## Phase 2 — Formulate the hypothesis
+
+Synthesize the subagent findings into a single root-cause hypothesis:
+
+```
+Hypothesis: <one sentence naming the specific cause>
+
+Evidence:
+- <finding 1 from Thread A>
+- <finding 2 from Thread B>
+- ...
+
+Ruled out:
+- <alternative explanation X> — because <evidence>
+- <alternative explanation Y> — because <evidence>
+
+Confidence: high / medium / low
+Reason for confidence level: <explanation>
+```
+
+If multiple hypotheses remain viable, rank them by likelihood and note what evidence would distinguish between them.
+
+## Phase 3 — Reproduce
+
+Write a minimal reproduction that confirms the hypothesis. Aim for the smallest command, script, or test invocation that demonstrates the failure.
+
+```bash
+# Minimal repro — tee the output
+<repro-command> > troubleshoot-output/repro.txt 2>&1
+```
+
+Read the output and verify it shows the expected failure.
+
+**If reproduction succeeds:** note the exact repro command and its output in the report.
+
+**If reproduction fails (can't reproduce):** state this explicitly. Explain what you tried and why you think the failure may be environment-specific, timing-dependent, or already fixed. Do not guess at a root cause you cannot confirm.
+
+**If reproduction is destructive or would cause side effects:** describe the repro steps without running them. Flag clearly that human verification is needed.
+
+## Phase 4 — Report
+
+### TL;DR in chat first
+
+Always print the report in chat before touching any persistence target. The operator may be reading on a phone, in a hurry, or just not want a ticket comment for a quick investigation.
+
+```
+TL;DR
+
+Root cause: <one sentence>
+Confidence: high / medium / low — <reason>
+
+Repro: <minimal repro command>  (output → troubleshoot-output/repro.txt)
+
+Next step: <fix suggestion, or what input is needed>
+
+Ruled out: <alternative X> (reason), <alternative Y> (reason)
+
+Artifacts: troubleshoot-output/
+```
+
+### Ask about persistence
+
+After printing the TL;DR, ask explicitly — do not assume:
+
+> "Save these findings somewhere?
+> - **a)** Linear comment on [TICKET-ID]
+> - **b)** Design note update
+> - **c)** Local markdown file (`troubleshoot-output/report.md`)
+> - **d)** None — chat only is fine"
+
+Wait for the operator's answer before writing anything to disk, posting any comment, or updating any document. Multiple options can be selected (e.g. "a and c").
+
+### Persist on confirmation
+
+If the operator selects Linear comment, post:
+
+```markdown
+**Troubleshoot findings** (troubleshoot)
+
+**Root cause:**
+<one-sentence hypothesis>
+
+**Evidence:**
+- <finding 1>
+- <finding 2>
+
+**Reproduction:**
+```bash
+<minimal repro command>
+```
+Output: `troubleshoot-output/repro.txt`
+
+**Ruled out:**
+- <alternative X> — <reason>
+
+**Confidence:** high / medium / low — <reason>
+
+**Recommended next step:**
+<fix suggestion, or "needs human input on X before proceeding">
+
+**Investigation artifacts:** `troubleshoot-output/` (in working directory)
+```
+
+If the operator selects design note update or local file, write the same content to the appropriate target.
+
+## Phase 5 — Optional: hand off to /pairprog
+
+If the root cause is confirmed and a fix is clearly scoped, offer to hand off:
+
+> "Root cause confirmed. Ready to fix? I can invoke `/pairprog` to implement the fix atomically. The fix scope would be: [brief description]. Shall I proceed?"
+
+On approval, invoke the `pairprog` skill. Pass the diagnosis as context so pairprog can skip its own Phase 1 spike on this issue.
+
+On "not yet" or "no," leave the findings in the ticket comment. The operator decides when and how to fix.
+
+## Anti-patterns
+
+- **Don't fix code during investigation.** Diagnosis and repair are separate phases. Troubleshoot diagnoses; pairprog repairs. Mixing them produces unreviewed changes.
+- **Don't discard command output.** Every non-trivial command goes to `troubleshoot-output/`. Never run and discard.
+- **Don't report a hypothesis without a repro.** If you can't reproduce, say so — don't present an unconfirmed hypothesis as fact.
+- **Don't ask multiple rounds of questions.** One up-front batch at most. The operator walks away after that.
+- **Don't summarize investigations serially when they're independent.** Use parallel subagents. Time is the operator's scarcest resource.
+- **Don't ignore prior comments on the ticket.** Someone may have already investigated this. Read all comments before spawning subagents.
+- **Don't auto-persist.** Always ask before posting a Linear comment, writing a file, or updating a doc. Not every investigation warrants a paper trail.
+- **Don't post "starting investigation" comments.** Post findings, not progress pings. One consolidated comment per investigation session — and only after the operator says to.
+- **Don't leave troubleshoot-output/ unmentioned.** Always tell the operator where the artifacts are so they can inspect raw output if needed.
+- **Don't make destructive repro attempts.** If reproducing the failure would cause side effects (drop a DB, send emails, bill a customer), describe the steps and flag for human verification instead of running them.

--- a/flake.nix
+++ b/flake.nix
@@ -22,6 +22,7 @@
     inputs@{
       self,
       nixpkgs,
+      flake-utils,
       nix-darwin,
       home-manager,
       ...
@@ -58,7 +59,18 @@
           ++ machine.extraModules;
         };
     in
-    {
+    flake-utils.lib.eachSystem [ "x86_64-darwin" "aarch64-darwin" ] (
+      system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+      in
+      {
+        devShells.default = pkgs.mkShell {
+          packages = [ pkgs.emacs ];
+        };
+      }
+    )
+    // {
       darwinConfigurations = builtins.listToAttrs (
         map (machine: {
           inherit (machine) name;

--- a/home-darwin.nix
+++ b/home-darwin.nix
@@ -77,6 +77,7 @@
     ".emacs.d".source = config.lib.file.mkOutOfStoreSymlink "${dotfilesPath}/emacs";
     ".hammerspoon".source = config.lib.file.mkOutOfStoreSymlink ./hammerspoon;
     ".claude/skills".source = config.lib.file.mkOutOfStoreSymlink "${dotfilesPath}/claude/skills";
+    ".claude/settings.json".source = config.lib.file.mkOutOfStoreSymlink "${dotfilesPath}/claude/settings.json";
   };
   programs.vscode = {
     enable = true;

--- a/vim.nix
+++ b/vim.nix
@@ -20,6 +20,7 @@
       vim-gitgutter
     ];
     vimdiffAlias = true;
+    withPython3 = false; # disable Python bundled into nvim
     withRuby = true;
     extraConfig = ''
       set tabstop=2    " tab stop to 2 spaces


### PR DESCRIPTION
## Summary
- Adds standalone `/pr` skill for creating pull requests with minimal friction
- Auto-detects base branch — if the current branch is stacked on a feature branch rather than main, uses that as the base to preserve stack structure
- Pitches the full draft (title, base, body) in chat before creating anything; operator approves, edits, or cancels
- Composable — invocable directly or by other skills (/pairprog, /troubleshoot)

## Test plan
- [ ] Run `/pr` on a stacked branch and verify base is detected correctly
- [ ] Run `/pr` on a branch cut from main and verify base = main
- [ ] Verify no PR is created without explicit approval

https://linear.app/asabina/issue/VID-602

🤖 Generated with [Claude Code](https://claude.com/claude-code)