### PR TITLE
feat(agents): implement GitHub custom tool handlers (VID-611)

### DIFF
--- a/agents/src/tools/github.ts
+++ b/agents/src/tools/github.ts
@@ -1,0 +1,165 @@
+/**
+ * GitHub custom tool handlers.
+ *
+ * Replaces direct GITHUB_TOKEN env-var injection in the session container.
+ * Using custom tool dispatch + `limited` networking eliminates the prompt-injection
+ * exfiltration surface for the token.
+ *
+ * Each handler is async (input: Record<string, unknown>) => Promise<unknown>.
+ * The session runner dispatches agent.custom_tool_use events to these by name.
+ */
+
+type ToolInput = Record<string, unknown>;
+type ToolHandler = (input: ToolInput) => Promise<unknown>;
+
+const GITHUB_API = 'https://api.github.com';
+
+async function ghFetch(
+  token: string,
+  method: string,
+  path: string,
+  body?: unknown,
+): Promise<unknown> {
+  const res = await fetch(`${GITHUB_API}${path}`, {
+    method,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: 'application/vnd.github+json',
+      'X-GitHub-Api-Version': '2022-11-28',
+      ...(body ? { 'Content-Type': 'application/json' } : {}),
+    },
+    ...(body ? { body: JSON.stringify(body) } : {}),
+  });
+  if (!res.ok) {
+    throw new Error(`GitHub HTTP ${res.status}: ${await res.text()}`);
+  }
+  return res.json() as Promise<unknown>;
+}
+
+export function createGithubToolHandlers(token: string): Record<string, ToolHandler> {
+  const get = (path: string) => ghFetch(token, 'GET', path);
+  const post = (path: string, body: unknown) => ghFetch(token, 'POST', path, body);
+
+  return {
+    github_get_repo_info: ({ owner, repo }) =>
+      get(`/repos/${owner}/${repo}`),
+
+    github_get_default_branch: async ({ owner, repo }) => {
+      const info = (await get(`/repos/${owner}/${repo}`)) as { default_branch: string };
+      return { default_branch: info.default_branch };
+    },
+
+    github_push_branch: async ({ owner, repo, branch, base, files }) => {
+      // 1. Resolve base SHA
+      const baseRef = (await get(
+        `/repos/${owner}/${repo}/git/refs/heads/${base}`,
+      )) as { object: { sha: string } };
+      const baseSha = baseRef.object.sha;
+
+      // 2. Build tree entries (base64 blobs)
+      const fileList = files as Array<{ path: string; content: string }>;
+      const tree = fileList.map((f) => ({
+        path: f.path,
+        mode: '100644',
+        type: 'blob',
+        content: f.content,
+      }));
+
+      const treeRes = (await post(`/repos/${owner}/${repo}/git/trees`, {
+        base_tree: baseSha,
+        tree,
+      })) as { sha: string };
+
+      // 3. Create commit
+      const commitRes = (await post(`/repos/${owner}/${repo}/git/commits`, {
+        message: `chore: push branch ${branch}`,
+        tree: treeRes.sha,
+        parents: [baseSha],
+      })) as { sha: string };
+
+      // 4. Create branch ref
+      return post(`/repos/${owner}/${repo}/git/refs`, {
+        ref: `refs/heads/${branch}`,
+        sha: commitRes.sha,
+      });
+    },
+
+    github_create_pr: ({ owner, repo, title, body, head, base }) =>
+      post(`/repos/${owner}/${repo}/pulls`, { title, body, head, base }),
+  };
+}
+
+/** JSON Schema definitions for registering custom tools on an agent. */
+export const githubToolSchemas: Array<{
+  name: string;
+  description: string;
+  input_schema: object;
+}> = [
+  {
+    name: 'github_get_repo_info',
+    description: 'Get repository metadata from GitHub',
+    input_schema: {
+      type: 'object',
+      properties: {
+        owner: { type: 'string', description: 'Repository owner (user or org)' },
+        repo: { type: 'string', description: 'Repository name' },
+      },
+      required: ['owner', 'repo'],
+    },
+  },
+  {
+    name: 'github_get_default_branch',
+    description: 'Get the default branch name of a GitHub repository',
+    input_schema: {
+      type: 'object',
+      properties: {
+        owner: { type: 'string', description: 'Repository owner (user or org)' },
+        repo: { type: 'string', description: 'Repository name' },
+      },
+      required: ['owner', 'repo'],
+    },
+  },
+  {
+    name: 'github_push_branch',
+    description:
+      'Create a new branch on GitHub by committing a set of files on top of a base branch',
+    input_schema: {
+      type: 'object',
+      properties: {
+        owner: { type: 'string', description: 'Repository owner' },
+        repo: { type: 'string', description: 'Repository name' },
+        branch: { type: 'string', description: 'New branch name to create' },
+        base: { type: 'string', description: 'Base branch to branch from' },
+        files: {
+          type: 'array',
+          description: 'Files to include in the commit',
+          items: {
+            type: 'object',
+            properties: {
+              path: { type: 'string' },
+              content: { type: 'string' },
+            },
+            required: ['path', 'content'],
+          },
+        },
+      },
+      required: ['owner', 'repo', 'branch', 'base', 'files'],
+    },
+  },
+  {
+    name: 'github_create_pr',
+    description: 'Create a pull request on GitHub',
+    input_schema: {
+      type: 'object',
+      properties: {
+        owner: { type: 'string', description: 'Repository owner' },
+        repo: { type: 'string', description: 'Repository name' },
+        title: { type: 'string', description: 'PR title' },
+        body: { type: 'string', description: 'PR description body' },
+        head: { type: 'string', description: 'Branch containing the changes' },
+        base: { type: 'string', description: 'Branch to merge into' },
+      },
+      required: ['owner', 'repo', 'title', 'head', 'base'],
+    },
+  },
+];

--- a/agents/tests/tools/github.test.ts
+++ b/agents/tests/tools/github.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createGithubToolHandlers } from '../../src/tools/github.js';
+
+const TOKEN = 'test-github-token';
+
+function mockFetch(responseData: unknown) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(responseData),
+    }),
+  );
+}
+
+function mockFetchError(status: number, body: string) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue({
+      ok: false,
+      status,
+      text: () => Promise.resolve(body),
+    }),
+  );
+}
+
+function lastFetchCall(): [string, RequestInit] {
+  const calls = vi.mocked(fetch).mock.calls;
+  return calls[calls.length - 1] as [string, RequestInit];
+}
+
+beforeEach(() => vi.unstubAllGlobals());
+
+describe('createGithubToolHandlers', () => {
+  const handlers = createGithubToolHandlers(TOKEN);
+
+  it('sends Authorization header with Bearer token', async () => {
+    mockFetch({ default_branch: 'main' });
+    await handlers['github_get_default_branch']!({ owner: 'acme', repo: 'widget' });
+    const [, init] = lastFetchCall();
+    expect((init.headers as Record<string, string>)['Authorization']).toBe(`Bearer ${TOKEN}`);
+  });
+
+  it('sends Accept: application/vnd.github+json header', async () => {
+    mockFetch({ default_branch: 'main' });
+    await handlers['github_get_default_branch']!({ owner: 'acme', repo: 'widget' });
+    const [, init] = lastFetchCall();
+    expect((init.headers as Record<string, string>)['Accept']).toBe(
+      'application/vnd.github+json',
+    );
+  });
+
+  it('sends X-GitHub-Api-Version header', async () => {
+    mockFetch({ default_branch: 'main' });
+    await handlers['github_get_default_branch']!({ owner: 'acme', repo: 'widget' });
+    const [, init] = lastFetchCall();
+    expect((init.headers as Record<string, string>)['X-GitHub-Api-Version']).toBe('2022-11-28');
+  });
+
+  describe('github_get_repo_info', () => {
+    it('calls GET /repos/{owner}/{repo}', async () => {
+      const repoData = { id: 1, name: 'widget', default_branch: 'main' };
+      mockFetch(repoData);
+      const result = await handlers['github_get_repo_info']!({ owner: 'acme', repo: 'widget' });
+      const [url, init] = lastFetchCall();
+      expect(url).toBe('https://api.github.com/repos/acme/widget');
+      expect(init.method).toBe('GET');
+      expect(result).toEqual(repoData);
+    });
+  });
+
+  describe('github_get_default_branch', () => {
+    it('calls GET /repos/{owner}/{repo} and returns default_branch', async () => {
+      mockFetch({ default_branch: 'trunk', id: 42 });
+      const result = await handlers['github_get_default_branch']!({
+        owner: 'acme',
+        repo: 'widget',
+      });
+      const [url] = lastFetchCall();
+      expect(url).toBe('https://api.github.com/repos/acme/widget');
+      expect(result).toEqual({ default_branch: 'trunk' });
+    });
+  });
+
+  describe('github_create_pr', () => {
+    it('calls POST /repos/{owner}/{repo}/pulls with correct body', async () => {
+      const prData = { number: 7, html_url: 'https://github.com/acme/widget/pull/7' };
+      mockFetch(prData);
+      const result = await handlers['github_create_pr']!({
+        owner: 'acme',
+        repo: 'widget',
+        title: 'Add feature',
+        body: 'Description here',
+        head: 'feature-branch',
+        base: 'main',
+      });
+      const [url, init] = lastFetchCall();
+      expect(url).toBe('https://api.github.com/repos/acme/widget/pulls');
+      expect(init.method).toBe('POST');
+      const sentBody = JSON.parse(init.body as string);
+      expect(sentBody).toEqual({
+        title: 'Add feature',
+        body: 'Description here',
+        head: 'feature-branch',
+        base: 'main',
+      });
+      expect(result).toEqual(prData);
+    });
+  });
+
+  describe('github_push_branch', () => {
+    it('calls ref, tree, commit, and ref-create endpoints in order', async () => {
+      const fetchMock = vi.fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve({ object: { sha: 'base-sha-123' } }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve({ sha: 'tree-sha-456' }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve({ sha: 'commit-sha-789' }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve({ ref: 'refs/heads/new-branch', object: { sha: 'commit-sha-789' } }),
+        });
+      vi.stubGlobal('fetch', fetchMock);
+
+      await handlers['github_push_branch']!({
+        owner: 'acme',
+        repo: 'widget',
+        branch: 'new-branch',
+        base: 'main',
+        files: [{ path: 'src/hello.ts', content: 'export const x = 1;' }],
+      });
+
+      const calls = fetchMock.mock.calls as [string, RequestInit][];
+      expect(calls).toHaveLength(4);
+
+      // Step 1: resolve base SHA
+      expect(calls[0][0]).toBe('https://api.github.com/repos/acme/widget/git/refs/heads/main');
+      expect(calls[0][1].method).toBe('GET');
+
+      // Step 2: create tree
+      expect(calls[1][0]).toBe('https://api.github.com/repos/acme/widget/git/trees');
+      expect(calls[1][1].method).toBe('POST');
+      const treeBody = JSON.parse(calls[1][1].body as string);
+      expect(treeBody.base_tree).toBe('base-sha-123');
+      expect(treeBody.tree[0].path).toBe('src/hello.ts');
+
+      // Step 3: create commit
+      expect(calls[2][0]).toBe('https://api.github.com/repos/acme/widget/git/commits');
+      expect(calls[2][1].method).toBe('POST');
+      const commitBody = JSON.parse(calls[2][1].body as string);
+      expect(commitBody.tree).toBe('tree-sha-456');
+      expect(commitBody.parents).toEqual(['base-sha-123']);
+
+      // Step 4: create branch ref
+      expect(calls[3][0]).toBe('https://api.github.com/repos/acme/widget/git/refs');
+      expect(calls[3][1].method).toBe('POST');
+      const refBody = JSON.parse(calls[3][1].body as string);
+      expect(refBody.ref).toBe('refs/heads/new-branch');
+      expect(refBody.sha).toBe('commit-sha-789');
+    });
+  });
+
+  describe('error handling', () => {
+    it('throws with status code on HTTP error', async () => {
+      mockFetchError(404, 'Not Found');
+      await expect(
+        handlers['github_get_repo_info']!({ owner: 'acme', repo: 'nonexistent' }),
+      ).rejects.toThrow(/GitHub HTTP 404/);
+    });
+
+    it('throws with status code on 401 unauthorized', async () => {
+      mockFetchError(401, 'Bad credentials');
+      await expect(
+        handlers['github_get_default_branch']!({ owner: 'acme', repo: 'widget' }),
+      ).rejects.toThrow(/GitHub HTTP 401/);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `agents/src/tools/github.ts` with four MCP-compatible tool handlers: `github_get_repo_info`, `github_get_default_branch`, `github_push_branch`, `github_create_pr`
- Follows the same `createXxxToolHandlers(token)` + `xxxToolSchemas` export shape as `linear.ts`
- Replaces direct `GITHUB_TOKEN` env injection in the session container — custom tool dispatch + `limited` networking eliminates the prompt-injection exfiltration surface

## Test plan

- [x] `devenv shell -- pnpm test:run` — all 26 tests pass (9 new in `github.test.ts`)
- [x] Auth header, each endpoint URL/method/body, HTTP 4xx error handling all covered
- [x] `github_push_branch` 4-step flow (ref resolution → tree → commit → ref create) asserted call-by-call

Stacked on: `vidbina/vid-607-try-ant`
Linear: https://linear.app/asabina/issue/VID-611

🤖 Generated with [Claude Code](https://claude.com/claude-code)