### PR TITLE
feat(claude): add statusLine command to display cwd in status bar

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -1,4 +1,8 @@
 {
+  "statusLine": {
+    "type": "command",
+    "command": "input=$(cat); echo \"$(echo \"$input\" | jq -r '.cwd')\""
+  },
   "permissions": {
     "allow": [
       "Glob",
@@ -34,4 +38,3 @@
     "obsidian@obsidian-skills": true
   }
 }
-{"apiKey": "sk-ant-api03-FAKEFAKEFAKEFAKEFAKEFAKE1234567890abcdef"}


### PR DESCRIPTION
## Summary

- Adds `statusLine` config to `claude/settings.json` with a command that
  reads the session context and echoes the current working directory
- Strips a stray non-JSON line that had been appended to the settings file

## Test plan

- [ ] Open Claude Code in this repo — status bar should show the cwd path
- [ ] Verify `claude/settings.json` is valid JSON (`jq . claude/settings.json`)

Stacked on: `vidbina/vid-607-try-ant`

🤖 Generated with [Claude Code](https://claude.com/claude-code)