### PR TITLE
Highlight active window for visibility (VID-626)

### DIFF
--- a/README.org
+++ b/README.org
@@ -2661,6 +2661,45 @@ Native macOS app built on Ghostty. Vertical tabs, notification rings when agents
 
 Just trying this because Theo won't stop switching tools and I have some spare time to try out some stuff. https://www.youtube.com/watch?v=EUE8N6mqtGg
 
+*** Window Management
+
+**** JankyBorders
+
+[[https://github.com/FelixKratz/JankyBorders][JankyBorders]] draws a colored border around the active window on macOS, making it immediately obvious which window has keyboard focus — particularly useful when long pauses or accidental touch/click events may silently shift focus without visual feedback. It renders borders without the Accessibility API, which makes it faster than alternatives that do. Requires macOS 14+.
+
+#+begin_src nix :noweb-ref homebrew-taps :noweb yes
+"FelixKratz/formulae"
+#+end_src
+
+#+begin_src nix :noweb-ref homebrew-brews :noweb yes
+"FelixKratz/formulae/borders"
+#+end_src
+
+Symlink the config into the expected XDG path. Using =${dotfilesPath}= to avoid the nix store coercion issue (see Claude section note).
+
+#+begin_src nix :noweb-ref home-darwin-home-file
+".config/borders/bordersrc".source = config.lib.file.mkOutOfStoreSymlink "${dotfilesPath}/borders/bordersrc";
+#+end_src
+
+The =bordersrc= is a shell script that =borders= reads on startup to configure border appearance:
+
+#+begin_src bash :tangle borders/bordersrc :tangle-mode (identity #o755) :mkdirp yes :shebang "#!/bin/bash"
+# Tangled from README.org — edit there, not here.
+# https://github.com/FelixKratz/JankyBorders
+
+borders \
+  active_color=0xffe1e3e4 \
+  inactive_color=0xff494d64 \
+  width=5.0 \
+  style=round &
+#+end_src
+
+After =nix-darwin-switch=, start the service manually once to verify, or add to login items:
+
+#+begin_src bash :eval no
+borders &
+#+end_src
+
 *** Networking
 
 Install Wireguard tools https://github.com/WireGuard/wireguard-tools on your MacOS.

--- a/README.org
+++ b/README.org
@@ -2671,8 +2671,14 @@ Just trying this because Theo won't stop switching tools and I have some spare t
 "FelixKratz/formulae"
 #+end_src
 
+nix-darwin can manage the borders service via launchd using the object form of the brew entry. =restart_service = "changed"= restarts borders when the formula is newly installed or upgraded.
+
 #+begin_src nix :noweb-ref homebrew-brews :noweb yes
-"FelixKratz/formulae/borders"
+{
+  name = "FelixKratz/formulae/borders";
+  start_service = true;
+  restart_service = "changed";
+}
 #+end_src
 
 Symlink the config into the expected XDG path. Using =${dotfilesPath}= to avoid the nix store coercion issue (see Claude section note).
@@ -2681,7 +2687,7 @@ Symlink the config into the expected XDG path. Using =${dotfilesPath}= to avoid 
 ".config/borders/bordersrc".source = config.lib.file.mkOutOfStoreSymlink "${dotfilesPath}/borders/bordersrc";
 #+end_src
 
-The =bordersrc= is a shell script that =borders= reads on startup to configure border appearance:
+The =bordersrc= is a shell script that =borders= reads on startup to configure border appearance. Since nix-darwin manages the service lifecycle, there is no trailing =&= — the service manager handles daemonization.
 
 #+begin_src bash :tangle borders/bordersrc :tangle-mode (identity #o755) :mkdirp yes :shebang "#!/bin/bash"
 # Tangled from README.org — edit there, not here.
@@ -2691,13 +2697,7 @@ borders \
   active_color=0xffe1e3e4 \
   inactive_color=0xff494d64 \
   width=5.0 \
-  style=round &
-#+end_src
-
-After =nix-darwin-switch=, start the service manually once to verify, or add to login items:
-
-#+begin_src bash :eval no
-borders &
+  style=round
 #+end_src
 
 *** Networking

--- a/README.org
+++ b/README.org
@@ -2689,16 +2689,49 @@ Symlink the config into the expected XDG path. Using =${dotfilesPath}= to avoid 
 
 The =bordersrc= is a shell script that =borders= reads on startup to configure border appearance. Since nix-darwin manages the service lifecycle, there is no trailing =&= — the service manager handles daemonization.
 
+Active color is the strong pink from [[https://asabina.de][asabina.de]] — =rgb(255, 85, 131)= → =0xffff5583= in JankyBorders' =0xAARRGGBB= format. This color is vivid enough to be legible on both light and dark backgrounds, so a single value works across themes.
+
 #+begin_src bash :tangle borders/bordersrc :tangle-mode (identity #o755) :mkdirp yes :shebang "#!/bin/bash"
 # Tangled from README.org — edit there, not here.
 # https://github.com/FelixKratz/JankyBorders
 
 borders \
-  active_color=0xffe1e3e4 \
+  active_color=0xffff5583 \
   inactive_color=0xff494d64 \
   width=5.0 \
   style=round
 #+end_src
+
+***** Light/dark theme switching
+
+JankyBorders does not natively watch for macOS appearance changes — it reads =bordersrc= once at startup. Two options for dynamic switching:
+
+****** Option A — single vivid color (current approach, simplest)
+
+The pink =0xffff5583= pops on both dark and light backgrounds. No switching logic needed. If the inactive color looks off in light mode, adjust =inactive_color= to a mid-grey like =0xff9ca0a8=.
+
+****** Option B — theme-aware restart via launchd WatchPaths
+
+Add a launchd agent that watches =~/Library/Preferences/.GlobalPreferences.plist= (where macOS writes =AppleInterfaceStyle= on theme change) and restarts the borders service when it changes.
+
+The =bordersrc= script detects the current theme at runtime:
+
+#+begin_src bash :eval no
+# detect dark mode: `defaults read -g AppleInterfaceStyle` returns "Dark" or exits non-zero in light mode
+if defaults read -g AppleInterfaceStyle 2>/dev/null | grep -q Dark; then
+  ACTIVE=0xffff5583    # pink on dark
+  INACTIVE=0xff494d64
+else
+  ACTIVE=0xffff5583    # same pink reads fine on light too
+  INACTIVE=0xff9ca0a8  # lighter inactive for light mode
+fi
+
+borders active_color=$ACTIVE inactive_color=$INACTIVE width=5.0 style=round
+#+end_src
+
+The WatchPaths agent would trigger =brew services restart borders= on plist change. This is more moving parts than Option A warrants unless the inactive color becomes a real issue in light mode.
+
+Stick with Option A for now; revisit if the inactive border is visually distracting in light mode.
 
 *** Networking
 

--- a/borders/bordersrc
+++ b/borders/bordersrc
@@ -3,7 +3,7 @@
 # https://github.com/FelixKratz/JankyBorders
 
 borders \
-  active_color=0xffe1e3e4 \
+  active_color=0xffff5583 \
   inactive_color=0xff494d64 \
   width=5.0 \
   style=round

--- a/borders/bordersrc
+++ b/borders/bordersrc
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Tangled from README.org — edit there, not here.
+# https://github.com/FelixKratz/JankyBorders
+
+borders \
+  active_color=0xffe1e3e4 \
+  inactive_color=0xff494d64 \
+  width=5.0 \
+  style=round &

--- a/borders/bordersrc
+++ b/borders/bordersrc
@@ -6,4 +6,4 @@ borders \
   active_color=0xffe1e3e4 \
   inactive_color=0xff494d64 \
   width=5.0 \
-  style=round &
+  style=round

--- a/configuration-darwin.nix
+++ b/configuration-darwin.nix
@@ -186,7 +186,11 @@ with lib;
       "coreutils"
       "wimlib"
       "micromamba"
-      "FelixKratz/formulae/borders"
+      {
+        name = "FelixKratz/formulae/borders";
+        start_service = true;
+        restart_service = "changed";
+      }
       "wireguard-tools"
       "pidof"
       "usbutils"

--- a/configuration-darwin.nix
+++ b/configuration-darwin.nix
@@ -179,12 +179,14 @@ with lib;
       upgrade = false; # same as default
     };
     taps = [
+      "FelixKratz/formulae"
       "anomalyco/tap"
     ];
     brews = [
       "coreutils"
       "wimlib"
       "micromamba"
+      "FelixKratz/formulae/borders"
       "wireguard-tools"
       "pidof"
       "usbutils"

--- a/home-darwin.nix
+++ b/home-darwin.nix
@@ -74,6 +74,7 @@
     ".config/git/ignore".source = config.lib.file.mkOutOfStoreSymlink ./git/ignore;
     ".wezterm.lua".source = ./wezterm/wezterm.lua;
     ".config/ghostty/config.ghostty".source = config.lib.file.mkOutOfStoreSymlink ./ghostty/config.ghostty;
+    ".config/borders/bordersrc".source = config.lib.file.mkOutOfStoreSymlink "${dotfilesPath}/borders/bordersrc";
     ".emacs.d".source = config.lib.file.mkOutOfStoreSymlink "${dotfilesPath}/emacs";
     ".hammerspoon".source = config.lib.file.mkOutOfStoreSymlink ./hammerspoon;
     ".claude/skills".source = config.lib.file.mkOutOfStoreSymlink "${dotfilesPath}/claude/skills";


### PR DESCRIPTION
## Summary
- Add JankyBorders via Homebrew for colored active-window borders on macOS
- Manage the borders service declaratively via nix-darwin launchd (`start_service = true`)
- Symlink `borders/bordersrc` into `~/.config/borders/` via `home.file` using `mkOutOfStoreSymlink`
- Active border color: asabina.de pink `rgb(255, 85, 131)` / `0xffff5583`; documents light/dark switching options

## Test plan
- [ ] Run `make tangle` and verify `borders/bordersrc` is regenerated correctly
- [ ] Run `darwin-rebuild switch` and confirm borders service starts via launchd
- [ ] Verify focused window shows pink border; unfocused windows show muted border

https://linear.app/asabina/issue/VID-626/highlight-active-window-for-visibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)