### PR TITLE
Update Claude settings: vim mode, ghostty notifications, settings reorder

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -1,8 +1,4 @@
 {
-  "statusLine": {
-    "type": "command",
-    "command": "input=$(cat); echo \"$(echo \"$input\" | jq -r '.cwd')\""
-  },
   "permissions": {
     "allow": [
       "Glob",
@@ -26,6 +22,13 @@
       "Bash(gh api*)"
     ]
   },
+  "statusLine": {
+    "type": "command",
+    "command": "input=$(cat); echo \"$(echo \"$input\" | jq -r '.cwd')\""
+  },
+  "enabledPlugins": {
+    "obsidian@obsidian-skills": true
+  },
   "extraKnownMarketplaces": {
     "obsidian-skills": {
       "source": {
@@ -34,9 +37,6 @@
       }
     }
   },
-  "enabledPlugins": {
-    "obsidian@obsidian-skills": true
-  }
   "editorMode": "vim",
   "preferredNotifChannel": "ghostty"
 }

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -37,4 +37,6 @@
   "enabledPlugins": {
     "obsidian@obsidian-skills": true
   }
+  "editorMode": "vim",
+  "preferredNotifChannel": "ghostty"
 }


### PR DESCRIPTION
## Summary
- Enable vim editor mode in Claude Code settings
- Set preferred notification channel to ghostty
- Reorder settings.json keys (Claude reformat on upsert, no functional change)

## Test plan
- [ ] Verify Claude Code opens with vim keybindings active
- [ ] Verify notifications route to ghostty

🤖 Generated with [Claude Code](https://claude.com/claude-code)