### PR TITLE
Add AI provenance markers to all skill outputs (VID-630)

### DIFF
--- a/claude/skills/commitmsg/SKILL.md
+++ b/claude/skills/commitmsg/SKILL.md
@@ -67,9 +67,14 @@ Analyze the changes:
 Apply the convention found in Step 1 to format the message. If the convention specifies:
 - A prefix format (e.g., `feat:`, `fix:`) — use it
 - A tag (e.g., `[ai:claude]`) — include it
-- A co-author line — include it
 - A max length — respect it
 - A body/footer structure — follow it
+
+**Always** include a `Co-Authored-By` trailer, regardless of whether the repo convention specifies one. This is the git-native AI provenance signal and renders distinctly in forge UIs (GitHub, GitLab show it as a secondary author avatar):
+
+```
+Co-Authored-By: Claude Code <noreply@anthropic.com>
+```
 
 Print the suggested message in a fenced code block so the user can copy it.
 

--- a/claude/skills/designnote/SKILL.md
+++ b/claude/skills/designnote/SKILL.md
@@ -204,6 +204,8 @@ Two modes: **create new** or **extend existing**.
 
    # Design Note: Human-Readable Title
 
+   > *Authored by Claude Code.*
+
    ## Status Log
 
    | Status | Date       | Author | Related Tickets | Notes                         |

--- a/claude/skills/linearissue/SKILL.md
+++ b/claude/skills/linearissue/SKILL.md
@@ -180,7 +180,7 @@ If the user bails, stop. Print nothing further.
 For each confirmed ticket:
 
 1. **Existing detection.** If the note's source-anchor area already has an inline `Linear: LIN-NNN` annotation, or if a Linear search by source anchor URL in the description footer finds an existing ticket, treat as **update**. Otherwise **create**.
-2. **Create:** call `save_issue` with team, project, title, description (including the source-anchor footer), priority, parent (if dependency-hinted as a sub-task — but default to flat unless the note structure clearly implies sub-tasking). Keep the description to 2–4 sentences maximum: one sentence on what the work is, one sentence on why it matters (if not obvious), and the source-anchor backlink. Do not copy prose, context, or reasoning from the design note into the description — the backlink is the bridge. If there is important context that should accompany the ticket, post it as a comment after creation instead.
+2. **Create:** call `save_issue` with team, project, title, description (including the source-anchor footer), priority, parent (if dependency-hinted as a sub-task — but default to flat unless the note structure clearly implies sub-tasking). Keep the description to 2–4 sentences maximum: one sentence on what the work is, one sentence on why it matters (if not obvious), and the source-anchor backlink. Prepend `*[ai:claude-code]*` as the first line of the description so authorship is visible before the content. Do not copy prose, context, or reasoning from the design note into the description — the backlink is the bridge. If there is important context that should accompany the ticket, post it as a comment after creation instead.
 3. **Update:** call `save_issue` with `id` set to the existing `LIN-NNN`, updating only fields that have meaningfully changed (description content, priority). Don't touch state, assignee, or labels unless explicitly indicated.
 4. **Capture** the returned ticket ID and URL.
 
@@ -243,7 +243,7 @@ For mixed intents, address all of them in a single pass rather than asking for c
 
 Produce one or both of:
 
-1. **Comment draft** — the primary output in almost all cases. Write it as you would a thoughtful comment from a collaborator: direct, specific, actionable. Scope crystallization, analysis, questions, and context all belong here.
+1. **Comment draft** — the primary output in almost all cases. Write it as you would a thoughtful comment from a collaborator: direct, specific, actionable. Scope crystallization, analysis, questions, and context all belong here. Always open the comment with `*[ai:claude-code]*` so readers know before the content.
 2. **Anchor update** — only if the intent is explicitly to fix the title or description. Draft the new title and/or description. Keep to 2–4 sentences. Do not migrate comment-appropriate content into the description.
 
 Print both drafts in chat before asking for confirmation. Make it easy to scan.

--- a/claude/skills/pairprog/SKILL.md
+++ b/claude/skills/pairprog/SKILL.md
@@ -105,6 +105,8 @@ Post a single comment to the ticket with the full assessment using `save_comment
 ```markdown
 **Assessment** (pairprog)
 
+*[ai:claude-code]*
+
 **Clear and ready:**
 - Add Google OAuth callback endpoint
 - Store refresh tokens in existing session table
@@ -135,6 +137,8 @@ Subagents are read-only investigators. They don't write production code.
 
 ```markdown
 **Spike: Google OAuth library compatibility** (pairprog)
+
+*[ai:claude-code]*
 
 **Verdict:** Feasible ✓
 
@@ -220,6 +224,8 @@ After the navigator approves (or adjusts) the plan, post it as a comment:
 ```markdown
 **Plan** (pairprog)
 
+*[ai:claude-code]*
+
 - [ ] Step 1: Add Google OAuth callback route
 - [ ] Step 2: Token storage in session metadata (parallel with 3)
 - [ ] Step 3: Silent token refresh middleware (parallel with 2)
@@ -248,6 +254,8 @@ After each step is committed (by the navigator in checkpoint mode, or auto-commi
 
 ```markdown
 **Step 1 complete** (pairprog)
+
+*[ai:claude-code]*
 
 Added Google OAuth callback route in `src/routes/auth.ts` and `src/config/oauth.ts`.
 Test added in `src/routes/__tests__/auth.test.ts` — passing.
@@ -331,6 +339,8 @@ Post a final session summary comment:
 
 ```markdown
 **Session complete** (pairprog)
+
+*[ai:claude-code]*
 
 **Completed:**
 - [x] Step 1: OAuth callback route

--- a/claude/skills/qsearch/SKILL.md
+++ b/claude/skills/qsearch/SKILL.md
@@ -191,8 +191,8 @@ If the user skips, stop. The chat output is the deliverable.
 
 ### Write
 
-- **Linear doc:** Use `create_document` with the report title and the full report content (adapted for Linear markdown — no front matter, inline metadata instead). If a `README: [Topic]` series doc exists in the target project, check it for any required internal structure or provenance block format and follow it.
-- **Markdown file:** Use `Write` to create the file with the kebab-case filename. Include a YAML front matter block with `title`, `date`, `scope`, and `sources` count.
+- **Linear doc:** Use `create_document` with the report title and the full report content (adapted for Linear markdown — no front matter, inline metadata instead). Start the document body with `*[ai:claude-code]*` so readers know before diving in. If a `README: [Topic]` series doc exists in the target project, check it for any required internal structure or provenance block format and follow it.
+- **Markdown file:** Use `Write` to create the file with the kebab-case filename. Include a YAML front matter block with `title`, `date`, `scope`, and `sources` count. On the first line of the document body (after the front matter), add `> *Authored by Claude Code.*` so the attribution is visible before the content.
 
 ## Anti-patterns
 

--- a/claude/skills/troubleshoot/SKILL.md
+++ b/claude/skills/troubleshoot/SKILL.md
@@ -168,6 +168,8 @@ If the operator selects Linear comment, post:
 ```markdown
 **Troubleshoot findings** (troubleshoot)
 
+*[ai:claude-code]*
+
 **Root cause:**
 <one-sentence hypothesis>
 


### PR DESCRIPTION
## Summary
- All pairprog Linear comments (assessment, spike, plan, step, wrap-up) now open with `*[ai:claude-code]*`
- commitmsg always appends `Co-Authored-By: Claude Code <noreply@anthropic.com>` regardless of repo convention; inline `[ai:tag]` remains repo-convention-dependent
- qsearch markdown reports get `> *Authored by Claude Code.*` after front matter; Linear docs get `*[ai:claude-code]*` as first line
- linearissue prepends `*[ai:claude-code]*` to new issue descriptions and iteration-mode comments
- troubleshoot Linear comments open with `*[ai:claude-code]*`
- designnote new-note template gets `> *Authored by Claude Code.*` after the title (extend mode untouched)
- pr and untypo: unchanged (pr already had the footer; untypo output is the user's own text)

## Test plan
- [ ] Run a pairprog session and verify Linear comments start with `*[ai:claude-code]*`
- [ ] Use commitmsg and verify `Co-Authored-By` trailer is always present
- [ ] Run qsearch and persist to file — verify attribution blockquote appears before Summary
- [ ] File a ticket via linearissue and verify description opens with `*[ai:claude-code]*`

https://linear.app/asabina/issue/VID-630/add-ai-provenance-markers-to-all-skill-outputs

🤖 Generated with [Claude Code](https://claude.com/claude-code)