### PR TITLE
Try gh copilot — install copilot-cli declaratively

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,3 +73,10 @@ This prevents:
 - Overwhelming the conversation
 - Loss of important information
 - Need to repeat expensive operations
+
+## Commit message conventions
+
+- **Format:** `<type>(<scope>): <subject> [ai:claude]` — the `[ai:claude]` tag always goes at the end of the subject line for AI-authored commits
+- **No ticket ID in subject:** the branch name already encodes the ticket (e.g. `vidbina/vid-616-...`); don't repeat it in the commit subject
+- **Always include:** `Co-Authored-By: Claude Code <noreply@anthropic.com>` trailer in the commit body
+- **Commit via nix develop:** pre-commit hooks require tools only available in the dev shell — always use `nix develop --command git commit`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,26 @@
 - **Read tool**: For examining specific files
 - **Glob tool**: For finding files by pattern
 
+## 🔥 CRITICAL RULE: ALWAYS PREFER DECLARATIVE SYSTEM CHANGES
+
+This repo uses literate config — `README.org` is the system config. Editing it IS the system change, expressed declaratively and version-controlled. The user runs `darwin-rebuild switch` (or `make switch`) to apply, as part of their normal workflow.
+
+### ⚠️ MANDATORY for ALL package/service/config changes:
+- **NEVER** run or suggest imperative installs (`brew install`, `gh extension install`, `pip install`, `npm install -g`, `cargo install`, etc.) — these bypass version control and leave ghost state
+- **ALWAYS** make the change in `README.org` (via the appropriate `noweb-ref` block) or the relevant nix module — that IS the install
+
+### Declarative paths in this repo:
+- **Homebrew brews:** `#+begin_src nix :noweb-ref homebrew-brews` in `README.org`
+- **Homebrew casks:** `#+begin_src nix :noweb-ref homebrew-casks` in `README.org`
+- **Nix packages:** `#+begin_src nix :noweb-ref dev-packages` or system/home-manager modules
+- **Services:** use nix-darwin launchd via object-form brew entry (`start_service = true`) or home-manager service modules
+
+### ❌ Never do imperatively:
+- `brew install <pkg>` → add to `homebrew-brews` noweb-ref instead
+- `brew install --cask <pkg>` → add to `homebrew-casks` noweb-ref instead
+- `gh extension install <ext>` → check if a standalone cask or nix package exists; prefer that
+- `pip install`, `npm install -g`, `cargo install` → use nix packages or home-manager
+
 ## Best Practices
 
 ### For Long Command Output:

--- a/README.org
+++ b/README.org
@@ -2347,6 +2347,14 @@ difftastic = {
 pkgs.gh
 #+end_src
 
+***** GitHub Copilot CLI
+
+[[https://formulae.brew.sh/cask/copilot-cli][copilot-cli]] provides the =gh copilot= extension as a standalone binary. We install it via Homebrew cask rather than =gh extension install github/gh-copilot= (imperative) or nix (nix unstable trails at 1.0.44 vs latest 1.0.48; nixpkgs 25.11 is even further back at 0.0.362). After the next =darwin-rebuild switch=, =gh copilot= will be available on PATH.
+
+#+begin_src nix :noweb-ref homebrew-casks :noweb yes
+"copilot-cli"
+#+end_src
+
 **** GitLab
 
 #+begin_src nix :noweb-ref dev-packages

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -27,7 +27,8 @@
     "command": "input=$(cat); echo \"$(echo \"$input\" | jq -r '.cwd')\""
   },
   "enabledPlugins": {
-    "obsidian@obsidian-skills": true
+    "obsidian@obsidian-skills": true,
+    "pyright-lsp@claude-plugins-official": true
   },
   "extraKnownMarketplaces": {
     "obsidian-skills": {

--- a/configuration-darwin.nix
+++ b/configuration-darwin.nix
@@ -202,6 +202,7 @@ with lib;
     casks = builtins.filter (x: x != null) [
       "zed"
       "cursor"
+      "copilot-cli"
       "android-file-transfer"
       "1password"
       "1password-cli"


### PR DESCRIPTION
## Summary
- Add `copilot-cli` as a Homebrew cask in `README.org` under the GitHub section, with rationale for brew over `gh extension install` (imperative) and nix (version lag)
- Update `AGENTS.md` to clarify that README.org edits are the declarative system change — imperative installs must be avoided; also document commit message conventions
- Enable `pyright-lsp` Claude Code plugin in `claude/settings.json`

## Test plan
- [ ] `gh copilot --version` returns a version after `darwin-rebuild switch`
- [ ] `gh copilot -i "explain list files"` opens an interactive Copilot session (note: `gh copilot explain "..."` without `-i` is invalid — use `-i` for interactive or `-p`/`--prompt` for non-interactive)

## Remaining scope (separate tickets)
- Local MCP wiring: add Linear MCP server to `~/.copilot/mcp-config.json` (VID-631)
- Cloud agent exploration: configure and test Copilot cloud agent (VID-632)

https://linear.app/asabina/issue/VID-616/try-gh-copilot

🤖 Generated with [Claude Code](https://claude.com/claude-code)