### PR TITLE
docs(agents): document slot-based worktree workflow (VID-634)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,6 +109,23 @@ git worktree prune
 - Each slot accumulates its own session history; nothing carries across slots automatically
 - Slot names are opaque: use `git branch --show-current` or your prompt to know what's checked out
 
+### Linear tickets as handover context
+
+Linear ticket comments are the async handover protocol between Claude sessions across worktrees.
+
+**Role split:**
+- `dotfiles/` (main) — orchestrator/dispatcher: high-level view, spawns work, posts context
+- `dotfiles--a/` (slot) — focused worker: picks up one ticket, implements, posts completion
+
+**Handover flow:**
+1. Orchestrator (or end of a slot session) posts a `**Handover**` comment to the Linear ticket with: current state, what's done, what's next, any relevant commands
+2. Worker session opens in the slot: `cd ../dotfiles--a && claude --continue` (or `-n <name>`)
+3. Worker reads the ticket comment to orient itself, then proceeds
+
+**Why Linear comments, not session files:** Comments are durable, visible outside the terminal, accessible from mobile, and tied to the ticket — not to a specific machine path or session ID. A cancelled session can always be resumed by any Claude instance that can read the ticket.
+
+**Naming convention for handover comments:** Start with `**Handover**` so they're scannable in the comment thread. End with a clear "Next step" section.
+
 ## Commit message conventions
 
 - **Format:** `<type>(<scope>): <subject> [ai:claude]` — the `[ai:claude]` tag always goes at the end of the subject line for AI-authored commits

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,41 @@ This prevents:
 - Loss of important information
 - Need to repeat expensive operations
 
+## Worktree workflow
+
+This repo uses a **slot-based worktree model** — fixed-path slots, not branch-named directories.
+
+```
+dotfiles/     ← main checkout, always on main
+dotfiles--a/  ← slot A
+dotfiles--b/  ← slot B (create as needed)
+```
+
+**Why slots, not branch-named paths:** Sessions are anchored to the CWD path. A branch-named worktree (`dotfiles-VID-NNN/`) loses session continuity when the branch advances (e.g. merge train A → B). A fixed slot path keeps the session bucket stable regardless of which branch is checked out.
+
+### Worktree setup
+
+```bash
+# Add a slot (first time)
+git worktree add ../dotfiles--a <branch>
+
+# Switch a slot to a different branch
+git -C ../dotfiles--a switch <branch>
+
+# List all worktrees
+git worktree list
+
+# Prune stale registrations
+git worktree prune
+```
+
+### Session discipline
+
+- Start each slot's Claude session from **inside** the slot directory: `cd ../dotfiles--a && claude -n <name>`
+- Resume with `--continue` from inside the slot — not from `dotfiles/`
+- Each slot accumulates its own session history; nothing carries across slots automatically
+- Slot names are opaque: use `git branch --show-current` or your prompt to know what's checked out
+
 ## Commit message conventions
 
 - **Format:** `<type>(<scope>): <subject> [ai:claude]` — the `[ai:claude]` tag always goes at the end of the subject line for AI-authored commits


### PR DESCRIPTION
## Summary

- Documents the slot-based worktree model in AGENTS.md (`dotfiles/`, `dotfiles--a/`, `dotfiles--b/`)
- Explains why fixed-path slots are preferred over branch-named worktree dirs (session continuity)
- Covers worktree setup commands and session discipline rules

## Test plan

- [x] Verify the worktree section renders correctly in AGENTS.md
- [x] Confirm slot-based layout matches what's described (worktrees already in use on this branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)