### PR TITLE
feat(ai): install superwhisper via homebrew cask

### DIFF
--- a/README.org
+++ b/README.org
@@ -5443,6 +5443,14 @@ We prefer Claude Code in a panel, so let's set that up so it will be honored in 
 "claudeCode.preferredLocation" = "panel";
 #+end_src
 
+*** Superwhisper
+
+[[https://superwhisper.com][Superwhisper]] is a macOS voice dictation tool built on Whisper with direct Claude Code and Claude Desktop integration (v2.13.0+, April 2026). It uses macOS accessibility APIs for context-aware transcription across modes ranging from fully offline (local Whisper/Parakeet) to cloud-assisted LLM post-processing. Selected in [[https://linear.app/asabina/issue/VID-640][VID-640]] research as the best fit for a Claude-heavy workflow.
+
+#+begin_src nix :noweb-ref homebrew-casks :noweb yes
+"superwhisper"
+#+end_src
+
 *** Gemini
 
 #+begin_src nix :noweb-ref dev-packages

--- a/configuration-darwin.nix
+++ b/configuration-darwin.nix
@@ -238,6 +238,7 @@ with lib;
       "linear-linear"
       "claude"
       "anthropics/tap/ant"
+      "superwhisper"
       (if pkgs.stdenv.hostPlatform.system == "aarch64-darwin" then "chatgpt" else null)
     ];
     masApps = {


### PR DESCRIPTION
## Summary

- Adds `superwhisper` to the `homebrew-casks` noweb-ref in `README.org` under the `** AI` section
- Includes a brief description linking back to VID-640 research and noting the Claude Code integration (v2.13.0+)
- After `darwin-rebuild switch`, Homebrew will install the cask automatically

Selected in [VID-640](https://linear.app/asabina/issue/VID-640) research as the best macOS voice dictation tool for a Claude-heavy workflow: direct Claude Code + Claude Desktop agent integration, offline STT modes via local Whisper/Parakeet, and macOS a11y API context capture.

## Test plan

- [x] Run `darwin-rebuild switch` (or `make switch`) to apply
- [x] Verify `Superwhisper.app` launches
- [ ] Verify global hotkey registers and dictation works

🤖 Generated with [Claude Code](https://claude.ai/claude-code)