### PR TITLE
feat(zsh): 256-color pink block + standout ↪ to anchor prompt in busy output

### DIFF
--- a/README.org
+++ b/README.org
@@ -1156,7 +1156,7 @@ vterm_prompt_end() {
     vterm_printf "51;A";
 }
 setopt PROMPT_SUBST
-PROMPT="↪ %(?.%F{green}√.%F{red}%?)%f" # error state
+PROMPT="%S%B↪%b%s %(?.%F{green}√.%F{red}%?)%f" # error state — standout ↪ anchors prompt in buffer
 PROMPT="$PROMPT → %F{yellow}%~%f" # pwd
 PROMPT="$PROMPT @ %F{magenta}%D{%Y.%m.%d} %B%F{blue}%T%f%b" # date/time
 PROMPT="$PROMPT"$'\n'
@@ -1734,7 +1734,7 @@ programs.zsh = {
         vterm_printf "51;A";
     }
     setopt PROMPT_SUBST
-    PROMPT="↪ %(?.%F{green}√.%F{red}%?)%f" # error state
+    PROMPT="%S%B↪%b%s %(?.%F{green}√.%F{red}%?)%f" # error state — standout ↪ anchors prompt in buffer
     PROMPT="$PROMPT → %F{yellow}%~%f" # pwd
     PROMPT="$PROMPT @ %F{magenta}%D{%Y.%m.%d} %B%F{blue}%T%f%b" # date/time
     PROMPT="$PROMPT"$'\n'

--- a/README.org
+++ b/README.org
@@ -1156,7 +1156,7 @@ vterm_prompt_end() {
     vterm_printf "51;A";
 }
 setopt PROMPT_SUBST
-PROMPT="%S%B↪%b%s %(?.%F{green}√.%F{red}%?)%f" # error state — standout ↪ anchors prompt in buffer
+PROMPT="%{$'\e[5m'%}%S%B↪%b%s%{$'\e[25m'%} %(?.%F{green}√.%F{red}%?)%f" # error state — blinking standout ↪ anchors prompt in buffer
 PROMPT="$PROMPT → %F{yellow}%~%f" # pwd
 PROMPT="$PROMPT @ %F{magenta}%D{%Y.%m.%d} %B%F{blue}%T%f%b" # date/time
 PROMPT="$PROMPT"$'\n'
@@ -1734,7 +1734,7 @@ programs.zsh = {
         vterm_printf "51;A";
     }
     setopt PROMPT_SUBST
-    PROMPT="%S%B↪%b%s %(?.%F{green}√.%F{red}%?)%f" # error state — standout ↪ anchors prompt in buffer
+    PROMPT="%{$'\e[5m'%}%S%B↪%b%s%{$'\e[25m'%} %(?.%F{green}√.%F{red}%?)%f" # error state — blinking standout ↪ anchors prompt in buffer
     PROMPT="$PROMPT → %F{yellow}%~%f" # pwd
     PROMPT="$PROMPT @ %F{magenta}%D{%Y.%m.%d} %B%F{blue}%T%f%b" # date/time
     PROMPT="$PROMPT"$'\n'

--- a/README.org
+++ b/README.org
@@ -1156,7 +1156,7 @@ vterm_prompt_end() {
     vterm_printf "51;A";
 }
 setopt PROMPT_SUBST
-PROMPT="%{"$'\e[5m'"%}%S%B↪%b%s%{"$'\e[25m'"%} %(?.%F{green}√.%F{red}%?)%f" # error state — blinking standout ↪ anchors prompt in buffer
+PROMPT="%K{205} %k%S%B↪%b%s %(?.%F{green}√.%F{red}%?)%f" # 256-color pink block (#FF5FAF) + standout ↪: two adjacent visual signals anchor the prompt in busy output
 PROMPT="$PROMPT → %F{yellow}%~%f" # pwd
 PROMPT="$PROMPT @ %F{magenta}%D{%Y.%m.%d} %B%F{blue}%T%f%b" # date/time
 PROMPT="$PROMPT"$'\n'
@@ -1734,7 +1734,7 @@ programs.zsh = {
         vterm_printf "51;A";
     }
     setopt PROMPT_SUBST
-    PROMPT="%{"$'\e[5m'"%}%S%B↪%b%s%{"$'\e[25m'"%} %(?.%F{green}√.%F{red}%?)%f" # error state — blinking standout ↪ anchors prompt in buffer
+    PROMPT="%K{205} %k%S%B↪%b%s %(?.%F{green}√.%F{red}%?)%f" # 256-color pink block (#FF5FAF) + standout ↪: two adjacent visual signals anchor the prompt in busy output
     PROMPT="$PROMPT → %F{yellow}%~%f" # pwd
     PROMPT="$PROMPT @ %F{magenta}%D{%Y.%m.%d} %B%F{blue}%T%f%b" # date/time
     PROMPT="$PROMPT"$'\n'

--- a/README.org
+++ b/README.org
@@ -1156,7 +1156,7 @@ vterm_prompt_end() {
     vterm_printf "51;A";
 }
 setopt PROMPT_SUBST
-PROMPT="%{$'\e[5m'%}%S%B↪%b%s%{$'\e[25m'%} %(?.%F{green}√.%F{red}%?)%f" # error state — blinking standout ↪ anchors prompt in buffer
+PROMPT="%{"$'\e[5m'"%}%S%B↪%b%s%{"$'\e[25m'"%} %(?.%F{green}√.%F{red}%?)%f" # error state — blinking standout ↪ anchors prompt in buffer
 PROMPT="$PROMPT → %F{yellow}%~%f" # pwd
 PROMPT="$PROMPT @ %F{magenta}%D{%Y.%m.%d} %B%F{blue}%T%f%b" # date/time
 PROMPT="$PROMPT"$'\n'
@@ -1734,7 +1734,7 @@ programs.zsh = {
         vterm_printf "51;A";
     }
     setopt PROMPT_SUBST
-    PROMPT="%{$'\e[5m'%}%S%B↪%b%s%{$'\e[25m'%} %(?.%F{green}√.%F{red}%?)%f" # error state — blinking standout ↪ anchors prompt in buffer
+    PROMPT="%{"$'\e[5m'"%}%S%B↪%b%s%{"$'\e[25m'"%} %(?.%F{green}√.%F{red}%?)%f" # error state — blinking standout ↪ anchors prompt in buffer
     PROMPT="$PROMPT → %F{yellow}%~%f" # pwd
     PROMPT="$PROMPT @ %F{magenta}%D{%Y.%m.%d} %B%F{blue}%T%f%b" # date/time
     PROMPT="$PROMPT"$'\n'

--- a/claude/skills/pairprog/SKILL.md
+++ b/claude/skills/pairprog/SKILL.md
@@ -248,6 +248,8 @@ For each step:
    - **Checkpoint mode:** Pause for the navigator's feedback. If the navigator says "looks good," they commit. If they want changes, iterate.
    - **Yolo mode:** Invoke the `commitmsg` skill's methodology (read repo convention, draft message) and auto-commit. Print the commit hash and message. Continue to the next step.
 
+   **Yolo commit discipline:** Commit immediately after each step passes quality checks — before starting the next step. Do not batch changes across steps and commit at the end. Committing on the go preserves the cleanest atomic boundary: each step's files haven't yet been mixed with the next step's. When a step spans multiple files (implementation + its tests), include all of them in the same commit. If the step also updates docs/config (env var examples, changelogs), bundle those in the same commit too — one logical concern, one commit.
+
 ### Comment step completions to Linear
 
 After each step is committed (by the navigator in checkpoint mode, or auto-committed in yolo mode), post a brief comment:

--- a/common.nix
+++ b/common.nix
@@ -110,7 +110,7 @@ in
           vterm_printf "51;A";
       }
       setopt PROMPT_SUBST
-      PROMPT="↪ %(?.%F{green}√.%F{red}%?)%f" # error state
+      PROMPT="%S%B↪%b%s %(?.%F{green}√.%F{red}%?)%f" # error state — standout ↪ anchors prompt in buffer
       PROMPT="$PROMPT → %F{yellow}%~%f" # pwd
       PROMPT="$PROMPT @ %F{magenta}%D{%Y.%m.%d} %B%F{blue}%T%f%b" # date/time
       PROMPT="$PROMPT"$'\n'

--- a/common.nix
+++ b/common.nix
@@ -110,7 +110,7 @@ in
           vterm_printf "51;A";
       }
       setopt PROMPT_SUBST
-      PROMPT="%S%B↪%b%s %(?.%F{green}√.%F{red}%?)%f" # error state — standout ↪ anchors prompt in buffer
+      PROMPT="%{"$'\e[5m'"%}%S%B↪%b%s%{"$'\e[25m'"%} %(?.%F{green}√.%F{red}%?)%f" # error state — blinking standout ↪ anchors prompt in buffer
       PROMPT="$PROMPT → %F{yellow}%~%f" # pwd
       PROMPT="$PROMPT @ %F{magenta}%D{%Y.%m.%d} %B%F{blue}%T%f%b" # date/time
       PROMPT="$PROMPT"$'\n'

--- a/common.nix
+++ b/common.nix
@@ -110,7 +110,7 @@ in
           vterm_printf "51;A";
       }
       setopt PROMPT_SUBST
-      PROMPT="%{"$'\e[5m'"%}%S%B↪%b%s%{"$'\e[25m'"%} %(?.%F{green}√.%F{red}%?)%f" # error state — blinking standout ↪ anchors prompt in buffer
+      PROMPT="%K{205} %k%S%B↪%b%s %(?.%F{green}√.%F{red}%?)%f" # 256-color pink block (#FF5FAF) + standout ↪: two adjacent visual signals anchor the prompt in busy output
       PROMPT="$PROMPT → %F{yellow}%~%f" # pwd
       PROMPT="$PROMPT @ %F{magenta}%D{%Y.%m.%d} %B%F{blue}%T%f%b" # date/time
       PROMPT="$PROMPT"$'\n'

--- a/configuration-darwin.nix
+++ b/configuration-darwin.nix
@@ -96,7 +96,7 @@ with lib;
           vterm_printf "51;A";
       }
       setopt PROMPT_SUBST
-      PROMPT="%{"$'\e[5m'"%}%S%B↪%b%s%{"$'\e[25m'"%} %(?.%F{green}√.%F{red}%?)%f" # error state — blinking standout ↪ anchors prompt in buffer
+      PROMPT="%K{205} %k%S%B↪%b%s %(?.%F{green}√.%F{red}%?)%f" # 256-color pink block (#FF5FAF) + standout ↪: two adjacent visual signals anchor the prompt in busy output
       PROMPT="$PROMPT → %F{yellow}%~%f" # pwd
       PROMPT="$PROMPT @ %F{magenta}%D{%Y.%m.%d} %B%F{blue}%T%f%b" # date/time
       PROMPT="$PROMPT"$'\n'

--- a/configuration-darwin.nix
+++ b/configuration-darwin.nix
@@ -96,7 +96,7 @@ with lib;
           vterm_printf "51;A";
       }
       setopt PROMPT_SUBST
-      PROMPT="%S%B↪%b%s %(?.%F{green}√.%F{red}%?)%f" # error state — standout ↪ anchors prompt in buffer
+      PROMPT="%{"$'\e[5m'"%}%S%B↪%b%s%{"$'\e[25m'"%} %(?.%F{green}√.%F{red}%?)%f" # error state — blinking standout ↪ anchors prompt in buffer
       PROMPT="$PROMPT → %F{yellow}%~%f" # pwd
       PROMPT="$PROMPT @ %F{magenta}%D{%Y.%m.%d} %B%F{blue}%T%f%b" # date/time
       PROMPT="$PROMPT"$'\n'

--- a/configuration-darwin.nix
+++ b/configuration-darwin.nix
@@ -96,7 +96,7 @@ with lib;
           vterm_printf "51;A";
       }
       setopt PROMPT_SUBST
-      PROMPT="↪ %(?.%F{green}√.%F{red}%?)%f" # error state
+      PROMPT="%S%B↪%b%s %(?.%F{green}√.%F{red}%?)%f" # error state — standout ↪ anchors prompt in buffer
       PROMPT="$PROMPT → %F{yellow}%~%f" # pwd
       PROMPT="$PROMPT @ %F{magenta}%D{%Y.%m.%d} %B%F{blue}%T%f%b" # date/time
       PROMPT="$PROMPT"$'\n'


### PR DESCRIPTION
## Summary
- Replaces bare `↪` with `%K{205} %k%S%B↪%b%s` — a hot-pink (#FF5FAF) space block followed by a standout/reverse-video bold arrow
- Uses 256-color index 205 instead of theme palette (0–15) so color is terminal-theme-independent
- Applied consistently in README.org (both PROMPT definition sites), common.nix, and configuration-darwin.nix

## Test plan
- [ ] `darwin-rebuild switch` applies the new promptInit string
- [ ] Pink block (`%K{205}`) renders as #FF5FAF, not grey
- [ ] `↪` renders in standout (reverse video) immediately after the pink block
- [ ] Exit status indicator (√ / error code) still correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)