### PR TITLE
test(ci): org file change — expect literate-config workflow to fire

### DIFF
--- a/README.org
+++ b/README.org
@@ -5,6 +5,7 @@
 #+STARTUP: overview
 
 These dotfiles make my life slightly more convenient. Not promising they'll do the same for yours though. 😉
+# ci-test: org file change — verifies literate-config workflow fires on .org edits
 
 * Usage
 


### PR DESCRIPTION
## Purpose

Verifies that the literate-config workflow fires when a \`.org\` file is modified.

## What changed

Inert comment added to `README.org` — no functional effect, only exists to touch an `.org` file and trigger the path filter in `.github/workflows/literate-config.yml`.

## Expected outcome

The **Literate Config** workflow should run on this PR.