### PR TITLE
feat(skills): codify Linear status transitions in pairprog, qsearch, pr

### DIFF
--- a/claude/skills/pairprog/SKILL.md
+++ b/claude/skills/pairprog/SKILL.md
@@ -2,7 +2,7 @@
 name: pairprog
 description: "Use this skill when the user wants to pair-program on a ticket — working through a Linear issue collaboratively with the AI driving and the human navigating. Trigger for prompts like 'let's work on this ticket', 'pair on LIN-123', 'pairprog', 'let's tackle this branch', 'work on the current branch', 'pick up LIN-123', 'start working on this', 'let's pair on this'. Also trigger when the user invokes `/pairprog`. The skill reads the current branch (or a specified ticket/branch), looks up the Linear ticket, explores the codebase for context, identifies unknowns and feasibility risks, asks the human navigator for direction on key decisions, then executes the work in atomic steps with frequent HITL checkpoints. It uses concurrent subagents to parallelize independent exploration and implementation work. It comments assessments, spike findings, and plans back to the Linear ticket so context survives across sessions. In default mode, the human commits after reviewing each atomic change. In yolo mode, the skill auto-commits atomically and gates at PR creation. This is NOT a walk-away skill. It is an interactive pairing session where the human stays engaged as navigator. Do NOT trigger for autonomous background work (use designnote or direct implementation), for ticket creation (use linearissue), for research without implementation (use qsearch), or for commit message drafting (use commitmsg)."
 api_description: "Pair-program on a Linear ticket: explore the codebase, assess unknowns, spike on feasibility, plan atomic steps, and implement with frequent HITL checkpoints. Posts assessments, spike findings, and progress back to the Linear ticket. Human commits each step; AI drives."
-allowed-tools: Bash Glob Grep Read Write Edit Task AskUserQuestion WebFetch mcp__claude_ai_Linear__get_issue mcp__claude_ai_Linear__list_issues mcp__claude_ai_Linear__list_comments mcp__claude_ai_Linear__save_comment mcp__claude_ai_Linear__list_teams mcp__claude_ai_Linear__get_team mcp__claude_ai_Linear__list_projects mcp__claude_ai_Linear__get_project mcp__claude_ai_Linear__list_issue_statuses mcp__claude_ai_Linear__list_issue_labels
+allowed-tools: Bash Glob Grep Read Write Edit Task AskUserQuestion WebFetch mcp__claude_ai_Linear__get_issue mcp__claude_ai_Linear__list_issues mcp__claude_ai_Linear__list_comments mcp__claude_ai_Linear__save_comment mcp__claude_ai_Linear__save_issue mcp__claude_ai_Linear__list_teams mcp__claude_ai_Linear__get_team mcp__claude_ai_Linear__list_projects mcp__claude_ai_Linear__get_project mcp__claude_ai_Linear__list_issue_statuses mcp__claude_ai_Linear__list_issue_labels
 ---
 
 # pairprog
@@ -52,7 +52,10 @@ If the ticket has a git branch name (from the Linear issue's `branchName` field 
 
 - Run `git fetch` to ensure the branch is available locally.
 - Run `git checkout {branch}` to switch to it.
-- If the branch doesn't exist yet, ask the navigator: "No branch for this ticket yet. Create `{suggested-branch-name}` from `main`?" On approval, create and check out.
+- If the branch doesn't exist yet, determine the correct base before asking:
+  - If the ticket is a sub-issue, check whether the parent ticket has a branch. If it does, that branch is the base — branching from `main` would break the stack's mergeability.
+  - If the ticket is top-level, default to `main` — but check whether there is an in-progress stack (e.g. a series of open PRs targeting each other) that this work should continue. If a stack exists, ask the navigator whether to extend it or start fresh from `main`.
+  - Ask: "No branch for this ticket yet. Create `{suggested-branch-name}` from `{base}`?" naming the resolved base explicitly. On approval, create and check out.
 
 If the user passed a branch name directly rather than a ticket ID, check it out if not already on it.
 
@@ -65,6 +68,10 @@ Once the ticket ID is known and the branch is checked out, fetch all of these in
 - **Branch state:** `git log --oneline -10`, `git status`, `git diff main...HEAD` (or appropriate base branch) to understand what's already been done on this branch.
 - **Codebase orientation:** Use `Task` with `subagent_type: Explore` to understand the areas of the codebase most likely relevant to the ticket (based on ticket title/description keywords).
 - **Repo conventions:** Read `CLAUDE.md` / `AGENTS.md` / `CONTRIBUTING.md` at the repo root for development workflow, testing, and quality requirements.
+
+### Transition to In Progress
+
+After the branch is checked out and the ticket is loaded, call `save_issue` with `id: {ticket-id}` and `state: "In Progress"`. Do this unconditionally — picking up the branch is the signal that work has started. No comment needed; the state change speaks for itself.
 
 ### Present the ticket
 
@@ -332,8 +339,9 @@ If the branch looks complete relative to the ticket scope:
 1. **Draft the PR pitch in chat.** Show the proposed title, body (summary of changes, test plan), and target branch. Format it so the navigator can review before anything is created.
 2. **Ask:** "Ready to create this PR via `gh`?" with options: **Yes, create it** / **Edit first** / **Not yet — more work needed**
 3. On approval, push the branch (`git push -u origin {branch}`) then create the PR using `gh pr create` via `Bash`.
-4. On "Edit first," let the navigator adjust the pitch, then create.
-5. On "Not yet," skip. The navigator will create it when ready.
+4. After `gh pr create` succeeds: call `save_issue` with `id: {ticket-id}` and `state: "In Review"`. No comment needed.
+5. On "Edit first," let the navigator adjust the pitch, then create.
+6. On "Not yet," skip. The navigator will create it when ready.
 
 ### Comment wrap-up to Linear
 

--- a/claude/skills/pr/SKILL.md
+++ b/claude/skills/pr/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: pr
 description: "Use this skill when the user wants to create a pull request for the current branch. Trigger for prompts like 'create a PR', 'open a PR', 'make a pull request', 'pr this', 'ship it', or when the user invokes `/pr`. Also invoked by other skills (/pairprog, /troubleshoot) at wrap-up. The skill detects the correct base branch automatically — if the current branch is stacked on another feature branch rather than main, it uses that branch as the base. It reads the Linear ticket (if any) and recent commits to draft a title and body, pitches the draft in chat for the operator to review, and creates the PR via `gh pr create` on approval. DX-first: fast, good defaults, minimal ceremony. Do NOT trigger for reviewing existing PRs, for merging, or for anything other than creating a new PR."
-allowed-tools: Bash Glob Grep Read AskUserQuestion mcp__claude_ai_Linear__get_issue mcp__claude_ai_Linear__list_comments
+allowed-tools: Bash Glob Grep Read AskUserQuestion mcp__claude_ai_Linear__get_issue mcp__claude_ai_Linear__save_issue mcp__claude_ai_Linear__list_comments
 ---
 
 # pr
@@ -103,6 +103,7 @@ Use `AskUserQuestion` to get the response. Options:
 1. **Push if needed:** if the branch isn't on origin yet, run `git push -u origin <branch>`. Print the push result.
 2. **Create:** run `gh pr create --base <base> --title "<title>" --body "<body>"` via `Bash`.
 3. **Print the PR URL** returned by `gh`.
+4. **Transition the ticket:** if a ticket ID was extracted from the branch name in Phase 1, call `save_issue` with `id: {ticket-id}` and `state: "In Review"`. This is unconditional — a PR being open means the work is ready for review.
 
 Done. No further action — merging, labeling, and assignment are human operations.
 

--- a/claude/skills/qsearch/SKILL.md
+++ b/claude/skills/qsearch/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: qsearch
 description: "Use this skill when the user asks you to quickly research, investigate, look into, find out about, compare, summarize, or get up-to-speed on a topic that benefits from fresh information from the web. Trigger for prompts like 'research X', 'qsearch Y', 'what are the best Y for Z', 'compare A vs B', 'find me sources on...', 'is it true that...', 'what's the current state of...', 'dig into...', or any question where a good answer requires fetching and synthesizing web content. Also trigger when the user invokes `/qsearch`. This skill batches any necessary clarifying questions into ONE up-front round before executing, so the user can answer them, walk away, and return to a finished artifact instead of being pinged for follow-ups throughout. Do NOT trigger for narrow factual questions answerable from training data, for code lookups better served by Grep/Glob, when the user provides specific URLs to fetch (just fetch them), or when the user explicitly says 'no web search' / 'from what you know'."
-allowed-tools: WebSearch WebFetch AskUserQuestion Glob Grep Read Write mcp__claude_ai_Linear__list_projects mcp__claude_ai_Linear__get_project mcp__claude_ai_Linear__list_documents mcp__claude_ai_Linear__get_document mcp__claude_ai_Linear__create_document
+allowed-tools: WebSearch WebFetch AskUserQuestion Glob Grep Read Write mcp__claude_ai_Linear__get_issue mcp__claude_ai_Linear__save_issue mcp__claude_ai_Linear__list_projects mcp__claude_ai_Linear__get_project mcp__claude_ai_Linear__list_documents mcp__claude_ai_Linear__get_document mcp__claude_ai_Linear__create_document
 ---
 
 # qsearch
@@ -140,6 +140,14 @@ Restate the locked decisions from Phase 2 in a compact form so the user can cour
 
 After printing the report to chat (Phase 5), offer to persist it as a named research report. This phase is the only exception to the "no more questions after Phase 2" rule — persistence is a post-delivery HITL gate, not a mid-research interruption.
 
+### Ticket-scoped invocations
+
+If a ticket ID was explicitly part of the invocation (e.g. `qsearch VID-524`), read the ticket with `get_issue` before starting Phase 1. If the ticket does not look like a research-scoped ticket (e.g. it describes implementation work, a bug fix, or a feature rather than investigation), flag this before proceeding:
+
+> "VID-524 looks like an implementation ticket, not a research one. Running qsearch against it will produce a report but won't map naturally to the ticket's scope. Options: (a) proceed anyway, (b) I suggest creating a research sub-issue or blocking research ticket first — do you want me to outline that structure?"
+
+Offer the options via `AskUserQuestion`. If the navigator proceeds, continue normally. If they want a research sub-issue, outline a proposed ticket title/description in chat for review — do not create it automatically.
+
 ### Report naming convention
 
 Reports follow a fixed title scheme:
@@ -193,6 +201,12 @@ If the user skips, stop. The chat output is the deliverable.
 
 - **Linear doc:** Use `create_document` with the report title and the full report content (adapted for Linear markdown — no front matter, inline metadata instead). Start the document body with `*[ai:claude-code]*` so readers know before diving in. If a `README: [Topic]` series doc exists in the target project, check it for any required internal structure or provenance block format and follow it.
 - **Markdown file:** Use `Write` to create the file with the kebab-case filename. Include a YAML front matter block with `title`, `date`, `scope`, and `sources` count. On the first line of the document body (after the front matter), add `> *Authored by Claude Code.*` so the attribution is visible before the content.
+
+### Ticket status transition
+
+After the report is delivered to chat and persistence is handled (or skipped): if a ticket ID was explicitly part of the invocation (e.g. `qsearch VID-524`), call `save_issue` with `id: {ticket-id}` and `state: "In Review"`. Findings are ready for operator evaluation — the ticket should reflect that. No comment needed; the report itself is the artifact.
+
+Only apply this when a ticket ID was explicitly in the invocation. Do not transition on open-ended research queries with no ticket context.
 
 ## Anti-patterns
 


### PR DESCRIPTION
## Summary
- `pairprog` now transitions tickets to **In Progress** on Phase 0 pickup and **In Review** after a PR is created; also expands branch-base logic to check parent issues and stacks before defaulting to `main`
- `qsearch` transitions ticket to **In Review** after report delivery on ticket-scoped invocations; flags non-research tickets with a suggestion to create a research sub-issue instead
- `pr` transitions ticket to **In Review** unconditionally after `gh pr create` succeeds, resolving the ticket ID from the branch name

## Test plan
- [ ] Run `/pairprog` on a fresh ticket — verify it transitions to In Progress on pickup
- [ ] Complete a pairprog session through PR creation — verify ticket moves to In Review
- [ ] Run `/qsearch VID-NNN` where the ticket is an implementation ticket — verify flag appears
- [ ] Run `/pr` on a branch with a ticket ID — verify ticket transitions to In Review after creation

Closes VID-647

🤖 Generated with [Claude Code](https://claude.com/claude-code)