### PR TITLE
feat(packages): add jless and fswatch

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,10 +39,18 @@ Some files in this repo are **tangled** (auto-generated) from `README.org`. Thes
 - **NEVER** run or suggest imperative installs (`brew install`, `gh extension install`, `pip install`, `npm install -g`, `cargo install`, etc.) — these bypass version control and leave ghost state
 - **ALWAYS** make the change in `README.org` (via the appropriate `noweb-ref` block) or the relevant nix module — that IS the install
 
+### Package source preference (nix-first)
+
+When adding a new package, prefer nixpkgs over Homebrew:
+
+1. **Check nixpkgs first:** `nix-env -qaP <pkg>` — if it exists, use a `dev-packages` noweb-ref block in `README.org`.
+2. **Check freshness:** compare the nixpkgs version against the upstream release. If nixpkgs is more than one major version behind, note it and consider Homebrew as a fallback.
+3. **Fall back to Homebrew** only for macOS-only GUI apps (casks) or when the nixpkgs version is too stale. Use `homebrew-brews` or `homebrew-casks` noweb-ref blocks.
+
 ### Declarative paths in this repo:
+- **Nix packages (preferred):** `#+begin_src nix :noweb-ref dev-packages` or system/home-manager modules
 - **Homebrew brews:** `#+begin_src nix :noweb-ref homebrew-brews` in `README.org`
 - **Homebrew casks:** `#+begin_src nix :noweb-ref homebrew-casks` in `README.org`
-- **Nix packages:** `#+begin_src nix :noweb-ref dev-packages` or system/home-manager modules
 - **Services:** use nix-darwin launchd via object-form brew entry (`start_service = true`) or home-manager service modules
 
 ### ❌ Never do imperatively:

--- a/README.org
+++ b/README.org
@@ -2985,11 +2985,12 @@ pkgs.tree-sitter
 #+end_src
 
 *** DSL
-**** jq, yq
+**** jq, yq, jless
 
 #+begin_src nix :noweb-ref dev-packages
 pkgs.jq
 pkgs.yq
+pkgs.jless
 #+end_src
 
 *** DB
@@ -3004,6 +3005,16 @@ pkgs.sqlite-interactive
 
 #+begin_src nix :noweb-ref dev-packages
 pkgs.redis
+#+end_src
+
+*** File system
+
+**** fswatch
+
+[[https://github.com/emcrisostomo/fswatch][fswatch]] is a cross-platform file change monitor using native OS APIs (FSEvents on macOS, inotify on Linux). Useful for triggering rebuilds or redraws on file changes.
+
+#+begin_src nix :noweb-ref dev-packages
+pkgs.fswatch
 #+end_src
 
 *** Linux Hacking

--- a/claude/skills/pairprog/SKILL.md
+++ b/claude/skills/pairprog/SKILL.md
@@ -17,7 +17,9 @@ The defining design principles are:
 >
 > **Derisk first.** Before writing production code, identify what's uncertain and spike on it. Feasibility unknowns resolved early prevent wasted work late.
 >
-> **Atomic steps with checkpoints.** Each change is small enough to review in one pass. The human sees the change, gives feedback, and commits when satisfied. No large PRs assembled silently.
+> **Atomic steps with checkpoints.** Each change is small enough to steer in one pass. The human sees the change, gives design feedback, and the session continues. Checkpoints are for steering, not code review.
+>
+> **PR-always.** Code review happens on GitHub, not in the CLI chat. Every session that produces code ends with a PR. GitHub has line comments, a mobile app, and formal review flows — it's a better review surface than chat. If a PR turns out wrong, close it or drop commits — PRs are cheap.
 >
 > **Parallel where possible.** Use subagents for independent exploration and implementation tasks. Don't serialize work that can run concurrently. But always reconvene with the navigator before acting on findings.
 >
@@ -25,16 +27,18 @@ The defining design principles are:
 
 ## Commit modes
 
-The skill supports two commit modes. Default is **checkpoint mode**. The navigator can switch to **yolo mode** at any time during the session.
+The skill supports two commit modes. The navigator can switch between them at any time during the session. A typical pattern on non-trivial work: start in checkpoint to refine the design through implementation, then switch to yolo once the remaining work is known and trivial.
 
-- **Checkpoint mode (default):** The skill presents each atomic change, the navigator reviews it, and the navigator commits manually. The skill never runs git write commands.
-- **Yolo mode:** The skill auto-commits each atomic step using the `commitmsg` skill for message generation, and gates at PR creation. The navigator can switch back to checkpoint mode at any time.
+- **Checkpoint mode:** The skill presents each atomic change and pauses for the navigator's steering input — design decisions, dropping constructs, changing approach. The navigator commits when satisfied. The skill never runs git write commands in this mode.
+- **Yolo mode:** The skill auto-commits each atomic step using the `commitmsg` skill for message generation. The navigator can interrupt at any time to steer.
 
 At the start of the session, if the skill detects this is a fresh ticket with no prior work, ask:
 
-> "Checkpoint mode (you review and commit each step) or yolo mode (I auto-commit, you review at PR time)?"
+> "Checkpoint or yolo? (You can switch anytime.)"
 
-If prior work exists on the branch, default to checkpoint without asking (the navigator is resuming deliberate work).
+Default to **checkpoint** for non-trivial work (multiple steps, unknowns). Default to **yolo** for simple/mechanical work (adding a package, small config change). If prior work exists on the branch, default to checkpoint without asking (the navigator is resuming deliberate work).
+
+**Important:** In both modes, code review happens via PR on GitHub — not in the CLI chat. Checkpoints are for design steering, not line-by-line code review. When the navigator wants to review code, offer to prep a PR: "Shall I ship a PR so you can review on GitHub?"
 
 ## Phase 0 — Pick up the ticket
 
@@ -277,7 +281,7 @@ For each step:
 4. **Run quality checks** if the repo has them (lint, typecheck, test). Use `Bash` for this. If a check fails, fix it before presenting.
 5. **Present the change.** Print a concise summary of what changed and why. Don't dump the full diff — describe the intent and highlight non-obvious decisions.
 6. **Checkpoint.**
-   - **Checkpoint mode:** Pause for the navigator's feedback. If the navigator says "looks good," they commit. If they want changes, iterate.
+   - **Checkpoint mode:** Pause for the navigator's steering input. This is about design direction — does this approach hold up? Should we change course? If the navigator says "looks good," they commit. If they want changes, iterate. Don't ask the navigator to review code line-by-line in chat — that's what the PR is for.
    - **Yolo mode:** Invoke the `commitmsg` skill's methodology (read repo convention, draft message) and auto-commit. Print the commit hash and message. Continue to the next step.
 
    **Yolo commit discipline:** Commit immediately after each step passes quality checks — before starting the next step. Do not batch changes across steps and commit at the end. Committing on the go preserves the cleanest atomic boundary: each step's files haven't yet been mixed with the next step's. When a step spans multiple files (implementation + its tests), include all of them in the same commit. If the step also updates docs/config (env var examples, changelogs), bundle those in the same commit too — one logical concern, one commit.

--- a/claude/skills/pairprog/SKILL.md
+++ b/claude/skills/pairprog/SKILL.md
@@ -2,7 +2,7 @@
 name: pairprog
 description: "Use this skill when the user wants to pair-program on a ticket — working through a Linear issue collaboratively with the AI driving and the human navigating. Trigger for prompts like 'let's work on this ticket', 'pair on LIN-123', 'pairprog', 'let's tackle this branch', 'work on the current branch', 'pick up LIN-123', 'start working on this', 'let's pair on this'. Also trigger when the user invokes `/pairprog`. The skill reads the current branch (or a specified ticket/branch), looks up the Linear ticket, explores the codebase for context, identifies unknowns and feasibility risks, asks the human navigator for direction on key decisions, then executes the work in atomic steps with frequent HITL checkpoints. It uses concurrent subagents to parallelize independent exploration and implementation work. It comments assessments, spike findings, and plans back to the Linear ticket so context survives across sessions. In default mode, the human commits after reviewing each atomic change. In yolo mode, the skill auto-commits atomically and gates at PR creation. This is NOT a walk-away skill. It is an interactive pairing session where the human stays engaged as navigator. Do NOT trigger for autonomous background work (use designnote or direct implementation), for ticket creation (use linearissue), for research without implementation (use qsearch), or for commit message drafting (use commitmsg)."
 api_description: "Pair-program on a Linear ticket: explore the codebase, assess unknowns, spike on feasibility, plan atomic steps, and implement with frequent HITL checkpoints. Posts assessments, spike findings, and progress back to the Linear ticket. Human commits each step; AI drives."
-allowed-tools: Bash Glob Grep Read Write Edit Task AskUserQuestion WebFetch mcp__claude_ai_Linear__get_issue mcp__claude_ai_Linear__list_issues mcp__claude_ai_Linear__list_comments mcp__claude_ai_Linear__save_comment mcp__claude_ai_Linear__save_issue mcp__claude_ai_Linear__list_teams mcp__claude_ai_Linear__get_team mcp__claude_ai_Linear__list_projects mcp__claude_ai_Linear__get_project mcp__claude_ai_Linear__list_issue_statuses mcp__claude_ai_Linear__list_issue_labels
+allowed-tools: Bash Glob Grep Read Write Edit Task Skill AskUserQuestion WebFetch mcp__claude_ai_Linear__get_issue mcp__claude_ai_Linear__list_issues mcp__claude_ai_Linear__list_comments mcp__claude_ai_Linear__save_comment mcp__claude_ai_Linear__save_issue mcp__claude_ai_Linear__list_teams mcp__claude_ai_Linear__get_team mcp__claude_ai_Linear__list_projects mcp__claude_ai_Linear__get_project mcp__claude_ai_Linear__list_issue_statuses mcp__claude_ai_Linear__list_issue_labels
 ---
 
 # pairprog
@@ -359,14 +359,11 @@ If there are uncommitted changes (checkpoint mode only):
 
 ### PR creation
 
-If the branch looks complete relative to the ticket scope:
+If the branch looks complete relative to the ticket scope, **delegate to the `/pr` skill.** Do not duplicate PR creation logic here — invoke it via the `Skill` tool with `skill: "pr"`.
 
-1. **Draft the PR pitch in chat.** Show the proposed title, body (summary of changes, test plan), and target branch. Format it so the navigator can review before anything is created.
-2. **Ask:** "Ready to create this PR via `gh`?" with options: **Yes, create it** / **Edit first** / **Not yet — more work needed**
-3. On approval, push the branch (`git push -u origin {branch}`) then create the PR using `gh pr create` via `Bash`.
-4. After `gh pr create` succeeds: call `save_issue` with `id: {ticket-id}` and `state: "In Review"`. No comment needed.
-5. On "Edit first," let the navigator adjust the pitch, then create.
-6. On "Not yet," skip. The navigator will create it when ready.
+The `/pr` skill handles: base branch detection (including stacked PRs), drafting the title and body from commits and the Linear ticket, pitching in chat for approval, pushing, creating via `gh`, transitioning the ticket to In Review, and launching a background CI monitor.
+
+If the navigator says "not yet" or "more work needed," skip. The navigator will create it when ready.
 
 ### Comment wrap-up to Linear
 

--- a/claude/skills/pr/SKILL.md
+++ b/claude/skills/pr/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: pr
 description: "Use this skill when the user wants to create a pull request for the current branch. Trigger for prompts like 'create a PR', 'open a PR', 'make a pull request', 'pr this', 'ship it', or when the user invokes `/pr`. Also invoked by other skills (/pairprog, /troubleshoot) at wrap-up. The skill detects the correct base branch automatically — if the current branch is stacked on another feature branch rather than main, it uses that branch as the base. It reads the Linear ticket (if any) and recent commits to draft a title and body, pitches the draft in chat for the operator to review, and creates the PR via `gh pr create` on approval. DX-first: fast, good defaults, minimal ceremony. Do NOT trigger for reviewing existing PRs, for merging, or for anything other than creating a new PR."
-allowed-tools: Bash Glob Grep Read AskUserQuestion mcp__claude_ai_Linear__get_issue mcp__claude_ai_Linear__save_issue mcp__claude_ai_Linear__list_comments
+allowed-tools: Bash Glob Grep Read Agent AskUserQuestion mcp__claude_ai_Linear__get_issue mcp__claude_ai_Linear__save_issue mcp__claude_ai_Linear__list_comments
 ---
 
 # pr
@@ -105,7 +105,30 @@ Use `AskUserQuestion` to get the response. Options:
 3. **Print the PR URL** returned by `gh`.
 4. **Transition the ticket:** if a ticket ID was extracted from the branch name in Phase 1, call `save_issue` with `id: {ticket-id}` and `state: "In Review"`. This is unconditional — a PR being open means the work is ready for review.
 
-Done. No further action — merging, labeling, and assignment are human operations.
+## Phase 6 — Monitor CI
+
+After the PR is created, launch a **background subagent** to monitor CI status. Do not suggest merging or offer to merge until CI results are in.
+
+The subagent should:
+
+1. **Poll CI checks** using `gh pr checks <pr-number> --watch` or periodic `gh pr checks <pr-number>` until all checks complete or a timeout (10 minutes) is reached.
+2. **On all checks green:**
+   - Report to the user: "CI passed on PR #N. Ready to merge."
+   - Check the repo's merge strategy: `gh api repos/{owner}/{repo} --jq '.allow_merge_commit, .allow_squash_merge, .allow_rebase_merge'`
+   - Offer to merge using the repo's preferred strategy, or let the user choose if multiple are enabled. Wait for explicit approval before running `gh pr merge`.
+3. **On any check red:**
+   - Report the failure: which check failed, link to the logs.
+   - Fetch the failure details: `gh pr checks <pr-number>` and `gh run view <run-id> --log-failed` for actionable output.
+   - Summarize what went wrong and suggest next steps (e.g. "lint failure in X — fixable here" or "test timeout — needs investigation").
+   - Ask the user how to proceed: fix it now (resume pairprog), investigate further, or leave it for later.
+4. **On timeout (no checks appear within 2 minutes):**
+   - Report: "No CI checks have started on PR #N. This repo may not have CI configured for this path, or checks are queued."
+   - Do not suggest merging.
+
+**Key rules:**
+- **Never suggest merging before CI results are known.** A freshly created PR has no check data — don't offer to merge it.
+- The subagent runs in the background so the user can continue other work.
+- If the user explicitly asks to merge before CI completes, warn them that checks haven't finished and confirm they want to proceed.
 
 ## Anti-patterns
 
@@ -114,3 +137,4 @@ Done. No further action — merging, labeling, and assignment are human operatio
 - **Don't fabricate the test plan.** Derive it from the diff or say "verify manually" — don't invent test steps that don't exist.
 - **Don't push without noting it.** If a push is needed, say so before running it.
 - **Don't ask more than one round of questions.** All clarification happens in the pitch → edit loop, not via separate `AskUserQuestion` calls before Phase 4.
+- **Don't suggest merging before CI is green.** A freshly created PR has no check data. Wait for the CI monitor subagent to report results before offering merge options.

--- a/home-darwin.nix
+++ b/home-darwin.nix
@@ -58,8 +58,10 @@
     pkgs.tree-sitter
     pkgs.jq
     pkgs.yq
+    pkgs.jless
     pkgs.sqlite-interactive
     pkgs.redis
+    pkgs.fswatch
     pkgs.claude-code
     pkgs.gemini-cli
     pkgs.codex


### PR DESCRIPTION
## Summary

- Add `jless` (JSON viewer/pager) and `fswatch` (file change monitor) to nixpkgs dev-packages
- Document nix-first package source preference in `AGENTS.md`: check nixpkgs availability and freshness before falling back to Homebrew
- `/pr` skill: add Phase 6 — background subagent monitors CI checks after PR creation, reports green/red, offers merge only when CI is confirmed green
- `/pairprog` skill: delegate PR creation to `/pr` instead of duplicating logic inline
- `/pairprog` skill: PR-always policy — code review happens on GitHub, not in CLI chat. Checkpoints are for design steering (direction, dropping constructs), not line-by-line code review

Fixes VID-653, VID-654

## Test plan

- [ ] `make verify-parity` passes
- [ ] `make switch` succeeds — `jless --version` and `fswatch --version` work
- [ ] Next pairprog session: verify `/pr` is invoked at wrap-up instead of inline PR logic
- [ ] Next PR creation: verify CI monitor subagent launches and reports status

🤖 Generated with [Claude Code](https://claude.com/claude-code)