### PR TITLE
feat(git): add git ready alias and post-merge cleanup

### DIFF
--- a/README.org
+++ b/README.org
@@ -2261,6 +2261,7 @@ lfs.enable = true;
 alias = {
   wdiff = "diff --word-diff --word-diff-regex='\\w+'";
   glog = "log --oneline --graph --all --decorate";
+  ready = "!git checkout main && git pull --ff-only";
 };
 #+end_src
 

--- a/claude/skills/pr/SKILL.md
+++ b/claude/skills/pr/SKILL.md
@@ -116,6 +116,7 @@ The subagent should:
    - Report to the user: "CI passed on PR #N. Ready to merge."
    - Check the repo's merge strategy: `gh api repos/{owner}/{repo} --jq '.allow_merge_commit, .allow_squash_merge, .allow_rebase_merge'`
    - Offer to merge using the repo's preferred strategy, or let the user choose if multiple are enabled. Wait for explicit approval before running `gh pr merge`.
+   - **After merge:** run `git checkout main && git pull --ff-only` (i.e. `git ready`) to return to a clean, up-to-date main. This is the ready position for starting new work. Transition linked tickets to Done.
 3. **On any check red:**
    - Report the failure: which check failed, link to the logs.
    - Fetch the failure details: `gh pr checks <pr-number>` and `gh run view <run-id> --log-failed` for actionable output.

--- a/home-darwin.nix
+++ b/home-darwin.nix
@@ -158,6 +158,7 @@
         alias = {
           wdiff = "diff --word-diff --word-diff-regex='\\w+'";
           glog = "log --oneline --graph --all --decorate";
+          ready = "!git checkout main && git pull --ff-only";
         };
         init = {
           defaultBranch = "main";


### PR DESCRIPTION
## Summary

- Add `git ready` alias: `git checkout main && git pull --ff-only` — returns to an up-to-date main, the starting position for new work
- Update `/pr` skill Phase 6: after a successful merge, run the checkout+pull dance to leave the session on a clean main. Transition linked tickets to Done.

## Test plan

- [ ] `make verify-parity` passes
- [ ] After `make switch`, `git ready` checks out main and pulls
- [ ] `git ready` fails cleanly with uncommitted changes (short-circuits on checkout)
- [ ] `git ready` fails cleanly if local main has diverged (`--ff-only` rejects)

🤖 Generated with [Claude Code](https://claude.com/claude-code)