### PR TITLE
fix(gref-dedup): use git-native remote ref color, restore hash coloring

### DIFF
--- a/README.org
+++ b/README.org
@@ -2260,7 +2260,7 @@ lfs.enable = true;
 #+begin_src nix :noweb-ref home-darwin-programs-git-settings
 alias = {
   wdiff = "diff --word-diff --word-diff-regex='\\w+'";
-  glog = "!git log --graph --all --format='%h %s%d' --color=always \"$@\" | gref-dedup | less -RF #";
+  glog = "!git log --graph --all --format='%C(auto)%h %s%d' --color=always \"$@\" | gref-dedup | less -RF #";
   ready = "!git checkout main && git pull --ff-only";
 };
 #+end_src

--- a/gref-dedup/src/main.rs
+++ b/gref-dedup/src/main.rs
@@ -3,7 +3,6 @@ use std::process::Command;
 
 // ANSI color codes matching git's default decoration scheme
 const RESET: &str = "\x1b[0m";
-const DIM: &str = "\x1b[2m";
 const CYAN_BOLD: &str = "\x1b[1;36m";
 const GREEN_BOLD: &str = "\x1b[1;32m";
 const RED_BOLD: &str = "\x1b[1;31m";
@@ -186,7 +185,7 @@ fn render_decoration(plain_inner: &str, remotes: &[String]) -> String {
 
     let head_prefix = if !head_branch_remotes.is_empty() {
         let prefix_str = head_branch_remotes.join(",");
-        format!("{DIM}[{prefix_str}/]{RESET}")
+        format!("{RED_BOLD}[{prefix_str}/]{RESET}")
     } else {
         String::new()
     };
@@ -213,7 +212,7 @@ fn render_decoration(plain_inner: &str, remotes: &[String]) -> String {
         } else {
             // local + remote(s), or multiple remotes — collapse
             let prefix_str = remote_prefixes.join(",");
-            parts.push(format!("{DIM}[{prefix_str}/]{RESET}{GREEN_BOLD}{tc}{RESET}"));
+            parts.push(format!("{RED_BOLD}[{prefix_str}/]{RESET}{GREEN_BOLD}{tc}{RESET}"));
         }
     }
 

--- a/home-darwin.nix
+++ b/home-darwin.nix
@@ -157,7 +157,7 @@
         #user.email = "vid@bina.me";
         alias = {
           wdiff = "diff --word-diff --word-diff-regex='\\w+'";
-          glog = "!git log --graph --all --format='%h %s%d' --color=always \"$@\" | gref-dedup | less -RF #";
+          glog = "!git log --graph --all --format='%C(auto)%h %s%d' --color=always \"$@\" | gref-dedup | less -RF #";
           ready = "!git checkout main && git pull --ff-only";
         };
         init = {


### PR DESCRIPTION
## Summary

- Change `[origin/]` collapsed prefix color from DIM (gray) to RED_BOLD to match git's native remote ref coloring
- Add `%C(auto)` to the glog format string to restore hash/subject coloring lost when switching from `--oneline` to `--format`
- Remove unused `DIM` constant

Fixes VID-656

## Test plan

- [ ] `nix develop --command cargo test --manifest-path gref-dedup/Cargo.toml` — 23 tests pass
- [ ] `make switch`, then `git glog` — hashes are yellow, `[origin/]` prefixes are red
- [ ] `make verify-parity` passes

https://linear.app/asabina/issue/VID-656/gref-dedup-use-git-native-remote-ref-color-for-origin-prefix-instead

🤖 Generated with [Claude Code](https://claude.com/claude-code)