### PR TITLE
Block imperative installs in yolo mode

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,7 @@ Some files in this repo are **tangled** (auto-generated) from `README.org`. Thes
 
 ### ⚠️ MANDATORY for ALL package/service/config changes:
 - **NEVER** run or suggest imperative installs (`brew install`, `gh extension install`, `pip install`, `npm install -g`, `cargo install`, etc.) — these bypass version control and leave ghost state
+- This rule applies **regardless of commit mode** — even in yolo mode, system-scope commands are always HITL. When a tool is missing, surface it to the user with context (e.g. "gitleaks is required by the pre-commit hook — install via `nix develop` or add to `README.org`?") rather than resolving it silently
 - **ALWAYS** make the change in `README.org` (via the appropriate `noweb-ref` block) or the relevant nix module — that IS the install
 
 ### Package source preference (nix-first)

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -106,7 +106,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "jq -r '.tool_input.command // \"\"' | grep -qE '(^|[[:space:];|&])(brew (install|uninstall|remove|upgrade)|pip install|npm install -g|cargo install|gem install|go install|gh extension install|nix-env -[iueq]|nix profile (install|remove)|nix-channel)' && echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"Imperative system modifications are blocked. Add packages declaratively via README.org (nix/homebrew noweb-ref blocks) instead. See AGENTS.md.\"}}' || true",
+            "command": "jq -r '.tool_input.command // \"\"' | grep -qE '(^|[[:space:];|&])(brew (install|uninstall|remove|upgrade)|pip install|npm install -g|cargo install|gem install|go install|gh extension install|nix-env -[iueq]|nix profile (install|remove)|nix-channel)' && echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"ask\",\"permissionDecisionReason\":\"Imperative system modifications are blocked. Add packages declaratively via README.org (nix/homebrew noweb-ref blocks) instead. See AGENTS.md.\"}}' || true",
             "timeout": 5
           }
         ]

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -106,7 +106,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "jq -r '.tool_input.command // \"\"' | grep -qE '(^|[[:space:];|&])(brew install|pip install|npm install -g|cargo install|gem install|go install|gh extension install)' && echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"Imperative installs are blocked. Add packages declaratively via README.org (nix/homebrew noweb-ref blocks) instead. See AGENTS.md.\"}}' || true",
+            "command": "jq -r '.tool_input.command // \"\"' | grep -qE '(^|[[:space:];|&])(brew (install|uninstall|remove|upgrade)|pip install|npm install -g|cargo install|gem install|go install|gh extension install|nix-env -[iueq]|nix profile (install|remove)|nix-channel)' && echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"Imperative system modifications are blocked. Add packages declaratively via README.org (nix/homebrew noweb-ref blocks) instead. See AGENTS.md.\"}}' || true",
             "timeout": 5
           }
         ]

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -99,6 +99,20 @@
       "mcp__claude_ai_Linear__delete_comment"
     ]
   },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -r '.tool_input.command // \"\"' | grep -qE '(^|[[:space:];|&])(brew install|pip install|npm install -g|cargo install|gem install|go install|gh extension install)' && echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"Imperative installs are blocked. Add packages declaratively via README.org (nix/homebrew noweb-ref blocks) instead. See AGENTS.md.\"}}' || true",
+            "timeout": 5
+          }
+        ]
+      }
+    ]
+  },
   "statusLine": {
     "type": "command",
     "command": "input=$(cat); echo \"$(echo \"$input\" | jq -r '.cwd')\""

--- a/claude/skills/pairprog/SKILL.md
+++ b/claude/skills/pairprog/SKILL.md
@@ -32,6 +32,8 @@ The skill supports two commit modes. The navigator can switch between them at an
 - **Checkpoint mode:** The skill presents each atomic change and pauses for the navigator's steering input — design decisions, dropping constructs, changing approach. The navigator commits when satisfied. The skill never runs git write commands in this mode.
 - **Yolo mode:** The skill auto-commits each atomic step using the `commitmsg` skill for message generation. The navigator can interrupt at any time to steer.
 
+**System-scope commands are always HITL, even in yolo mode.** Commands that modify system state (`brew install`, `npm install -g`, `pip install`, `cargo install`, etc.) are never auto-approved. When a tool is missing, surface it to the navigator with context (e.g. "gitleaks is required by the pre-commit hook — install via `nix develop` or approve `brew install gitleaks`?") rather than resolving it silently. Imperative installs bypass version control and can't be reviewed or rolled back.
+
 At the start of the session, if the skill detects this is a fresh ticket with no prior work, ask:
 
 > "Checkpoint or yolo? (You can switch anytime.)"


### PR DESCRIPTION
## Summary
- Strengthen AGENTS.md imperative install rule to explicitly apply regardless of commit mode — system-scope commands are always HITL
- Add carve-out in pairprog SKILL.md commit modes section: system-scope commands (`brew install`, `pip install`, etc.) are never auto-approved, even in yolo mode
- When a tool is missing, surface it to the navigator with context rather than resolving silently

## Test plan
- [ ] Verify AGENTS.md contains the yolo-mode carve-out under the imperative install rule
- [ ] Verify pairprog SKILL.md commit modes section mentions system-scope HITL requirement

https://linear.app/asabina/issue/VID-628/block-imperative-installs-in-yolo-mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)