### PR TITLE
Poppler-utils and Granola

### DIFF
--- a/README.org
+++ b/README.org
@@ -2994,6 +2994,16 @@ pkgs.yq
 pkgs.jless
 #+end_src
 
+*** Document tools
+
+**** Poppler
+
+[[https://poppler.freedesktop.org/][Poppler]] is a PDF rendering library that ships a suite of CLI utilities: =pdftotext=, =pdftoppm=, =pdfinfo=, =pdfimages=, =pdfseparate=, =pdfunite=, etc.
+
+#+begin_src nix :noweb-ref dev-packages
+pkgs.poppler-utils
+#+end_src
+
 *** DB
 
 **** SQLite

--- a/README.org
+++ b/README.org
@@ -5500,6 +5500,14 @@ We prefer Claude Code in a panel, so let's set that up so it will be honored in 
 "superwhisper"
 #+end_src
 
+**** Granola
+
+[[https://granola.ai][Granola]] is an AI meeting notepad for macOS that passively captures audio during meetings and generates structured notes.
+
+#+begin_src nix :noweb-ref homebrew-casks :noweb yes
+"granola"
+#+end_src
+
 *** Gemini
 
 #+begin_src nix :noweb-ref dev-packages

--- a/configuration-darwin.nix
+++ b/configuration-darwin.nix
@@ -240,6 +240,7 @@ with lib;
       "claude"
       "anthropics/tap/ant"
       "superwhisper"
+      "granola"
       (if pkgs.stdenv.hostPlatform.system == "aarch64-darwin" then "chatgpt" else null)
     ];
     masApps = {

--- a/home-darwin.nix
+++ b/home-darwin.nix
@@ -59,6 +59,7 @@
     pkgs.jq
     pkgs.yq
     pkgs.jless
+    pkgs.poppler-utils
     pkgs.sqlite-interactive
     pkgs.redis
     pkgs.fswatch


### PR DESCRIPTION
## Summary
- Add `poppler-utils` (PDF CLI tools: pdftotext, pdftoppm, etc.) via nixpkgs home-manager packages
- Add Granola (AI meeting notepad) via homebrew cask

## Test plan
- [ ] `which pdftotext` resolves after `nix-darwin-switch`
- [ ] Granola.app present in /Applications after switch

🤖 Generated with [Claude Code](https://claude.com/claude-code)