### PR TITLE
Poppler-utils, Granola, and Context7

### DIFF
--- a/README.org
+++ b/README.org
@@ -2994,6 +2994,16 @@ pkgs.yq
 pkgs.jless
 #+end_src
 
+*** Document tools
+
+**** Poppler
+
+[[https://poppler.freedesktop.org/][Poppler]] is a PDF rendering library that ships a suite of CLI utilities: =pdftotext=, =pdftoppm=, =pdfinfo=, =pdfimages=, =pdfseparate=, =pdfunite=, etc.
+
+#+begin_src nix :noweb-ref dev-packages
+pkgs.poppler-utils
+#+end_src
+
 *** DB
 
 **** SQLite

--- a/README.org
+++ b/README.org
@@ -5500,6 +5500,14 @@ We prefer Claude Code in a panel, so let's set that up so it will be honored in 
 "superwhisper"
 #+end_src
 
+**** Granola
+
+[[https://granola.ai][Granola]] is an AI meeting notepad for macOS that passively captures audio during meetings and generates structured notes.
+
+#+begin_src nix :noweb-ref homebrew-casks :noweb yes
+"granola"
+#+end_src
+
 *** Gemini
 
 #+begin_src nix :noweb-ref dev-packages

--- a/claude/skills/context7-mcp/SKILL.md
+++ b/claude/skills/context7-mcp/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: context7-mcp
+description: This skill should be used when the user asks about libraries, frameworks, API references, or needs code examples. Activates for setup questions, code generation involving libraries, or mentions of specific frameworks like React, Vue, Next.js, Prisma, Supabase, etc.
+---
+
+When the user asks about libraries, frameworks, or needs code examples, use Context7 to fetch current documentation instead of relying on training data.
+
+## When to Use This Skill
+
+Activate this skill when the user:
+
+- Asks setup or configuration questions ("How do I configure Next.js middleware?")
+- Requests code involving libraries ("Write a Prisma query for...")
+- Needs API references ("What are the Supabase auth methods?")
+- Mentions specific frameworks (React, Vue, Svelte, Express, Tailwind, etc.)
+
+## How to Fetch Documentation
+
+### Step 1: Resolve the Library ID
+
+Call `resolve-library-id` with:
+
+- `libraryName`: The library name extracted from the user's question
+- `query`: The user's full question (improves relevance ranking)
+
+### Step 2: Select the Best Match
+
+From the resolution results, choose based on:
+
+- Exact or closest name match to what the user asked for
+- Higher benchmark scores indicate better documentation quality
+- If the user mentioned a version (e.g., "React 19"), prefer version-specific IDs
+
+### Step 3: Fetch the Documentation
+
+Call `query-docs` with:
+
+- `libraryId`: The selected Context7 library ID (e.g., `/vercel/next.js`)
+- `query`: The user's specific question
+
+### Step 4: Use the Documentation
+
+Incorporate the fetched documentation into your response:
+
+- Answer the user's question using current, accurate information
+- Include relevant code examples from the docs
+- Cite the library version when relevant
+
+## Guidelines
+
+- **Be specific**: Pass the user's full question as the query for better results
+- **Version awareness**: When users mention versions ("Next.js 15", "React 19"), use version-specific library IDs if available from the resolution step
+- **Prefer official sources**: When multiple matches exist, prefer official/primary packages over community forks

--- a/configuration-darwin.nix
+++ b/configuration-darwin.nix
@@ -240,6 +240,7 @@ with lib;
       "claude"
       "anthropics/tap/ant"
       "superwhisper"
+      "granola"
       (if pkgs.stdenv.hostPlatform.system == "aarch64-darwin" then "chatgpt" else null)
     ];
     masApps = {

--- a/home-darwin.nix
+++ b/home-darwin.nix
@@ -59,6 +59,7 @@
     pkgs.jq
     pkgs.yq
     pkgs.jless
+    pkgs.poppler-utils
     pkgs.sqlite-interactive
     pkgs.redis
     pkgs.fswatch


### PR DESCRIPTION
## Summary
- Add `poppler-utils` (PDF CLI tools: pdftotext, pdftoppm, etc.) via nixpkgs home-manager packages
- Add Granola (AI meeting notepad) via homebrew cask
- Add Context7 MCP skill for fetching up-to-date library documentation

## Test plan
- [ ] `which pdftotext` resolves after `nix-darwin-switch`
- [ ] Granola.app present in /Applications after switch
- [ ] Context7 skill appears in Claude Code session skills list

🤖 Generated with [Claude Code](https://claude.com/claude-code)