### PR TITLE
DRY commenting protocol for skill-to-Linear interactions

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/README.org
+++ b/README.org
@@ -2994,6 +2994,16 @@ pkgs.yq
 pkgs.jless
 #+end_src
 
+*** Document tools
+
+**** Poppler
+
+[[https://poppler.freedesktop.org/][Poppler]] is a PDF rendering library that ships a suite of CLI utilities: =pdftotext=, =pdftoppm=, =pdfinfo=, =pdfimages=, =pdfseparate=, =pdfunite=, etc.
+
+#+begin_src nix :noweb-ref dev-packages
+pkgs.poppler-utils
+#+end_src
+
 *** DB
 
 **** SQLite

--- a/README.org
+++ b/README.org
@@ -2440,6 +2440,27 @@ direnv = {
 zsh.enable = true;
 #+end_src
 
+**** Project .envrc
+
+When a project provides a =flake.nix= with a =devShells.default=, a
+one-line =.envrc= enables automatic shell activation on =cd= via direnv
++ nix-direnv:
+
+#+begin_src bash :tangle .envrc
+use flake
+#+end_src
+
+**Why this is safe to track.** A =use flake= directive is a declarative
+tooling instruction — comparable to a =Makefile= or =.tool-versions=.
+It contains no secrets and is idempotent. The overwhelming majority of
+the Nix ecosystem (4 700+ repos on GitHub) commits these files. The
+=direnv allow= gate ensures no =.envrc= runs without explicit opt-in.
+
+**Secrets belong elsewhere.** If a project needs environment variables
+with sensitive values (API keys, database URLs), put them in
+=.envrc.local= or =.env= and add those to the project's =.gitignore=.
+Never put secrets in =.envrc=.
+
 **** Devenv
 
 #+begin_src nix :noweb-ref dev-packages

--- a/README.org
+++ b/README.org
@@ -5500,6 +5500,14 @@ We prefer Claude Code in a panel, so let's set that up so it will be honored in 
 "superwhisper"
 #+end_src
 
+**** Granola
+
+[[https://granola.ai][Granola]] is an AI meeting notepad for macOS that passively captures audio during meetings and generates structured notes.
+
+#+begin_src nix :noweb-ref homebrew-casks :noweb yes
+"granola"
+#+end_src
+
 *** Gemini
 
 #+begin_src nix :noweb-ref dev-packages

--- a/claude/skills/commenting/SKILL.md
+++ b/claude/skills/commenting/SKILL.md
@@ -1,0 +1,160 @@
+---
+name: commenting
+description: "Use this skill when another skill or the user needs to post a structured comment to a Linear issue. This skill owns the commenting protocol: thread lifecycle (anchor → replies → resolution), provenance markers, formatting, and threading via parentId. Trigger when a skill wants to post an assessment, finding, plan, status update, or session summary to a Linear issue. Also trigger when the user invokes `/commenting`. Do NOT use this skill for reading comments (use list_comments directly) or for creating/updating issues (use save_issue directly). This skill only handles comment creation with proper formatting and threading."
+api_description: "Post structured comments to Linear issues following a uniform protocol: thread anchors, threaded replies, provenance markers, and resolution semantics. Handles formatting and threading so calling skills don't have to."
+allowed-tools: mcp__claude_ai_Linear__save_comment mcp__claude_ai_Linear__list_comments mcp__claude_ai_Linear__get_issue
+---
+
+# commenting
+
+Post structured comments to Linear issues. This skill owns the **how** of commenting — formatting, provenance, threading. Calling skills own the **what** — when to comment and what content to include.
+
+## Protocol
+
+Every comment follows this structure:
+
+```
+Issue comments:
+├── Thread anchor (top-level): one per unit of work
+│   ├── Reply: interim update
+│   ├── Reply: interim update
+│   └── Reply: completion/resolution
+├── Thread anchor (top-level): another unit of work
+│   └── Reply: completion/resolution
+```
+
+### Comment anatomy
+
+Every comment has three parts:
+
+1. **Heading line:** `**{Title}** ({caller-skill})`
+2. **Provenance line:** `*[ai:claude-code]*`
+3. **Body:** the content, in markdown
+
+Example:
+
+```markdown
+**Assessment** (pairprog)
+
+*[ai:claude-code]*
+
+**Clear and ready:**
+- Add Google OAuth callback endpoint
+- Store refresh tokens in existing session table
+```
+
+### Thread lifecycle
+
+- **Anchor:** A top-level comment that starts a thread. One anchor per logical unit of work (one assessment, one spike, one plan, one session summary). Post with `save_comment(issueId, body)`.
+- **Reply:** A threaded response under an anchor. Used for updates, completions, and corrections to the anchor's unit of work. Post with `save_comment(issueId, body, parentId)` where `parentId` is the anchor's comment ID.
+- **Resolution:** The final reply in a thread. Prefix the heading with ✅ to signal completion: `**✅ Step 1 complete** (pairprog)`. (Linear MCP doesn't expose `resolvedAt`, so the emoji is the visual signal.)
+
+### When to anchor vs reply
+
+| Scenario | Action |
+|---|---|
+| New unit of work (assessment, plan, spike, investigation) | **Anchor** — new top-level comment |
+| Update to an existing unit (step progress, plan adjustment, interim finding) | **Reply** — thread under the anchor |
+| Completion of a unit (step done, session wrap-up, investigation concluded) | **Reply** with ✅ heading — thread under the anchor |
+| Unrelated new unit during same session | **Anchor** — new top-level comment |
+
+### Provenance
+
+The provenance marker identifies the authoring surface:
+
+- `*[ai:claude-code]*` — comment authored by Claude Code (interactive session)
+- `*[ai:managed-agent]*` — comment authored by a managed agent (walk-away)
+
+The marker always appears on line 3 (after heading + blank line), never inline or at the end.
+
+### Mid-thread events
+
+When something changes mid-thread (plan adjusted, step skipped, blocker found), use these emoji prefixes on the heading:
+
+- 🚨 — plan change
+- ⏭️ — step skipped
+- 🌟 — step added
+- 🚧 — blocker discovered
+- ⚠️ — conflict between plan and reality
+
+## Interface
+
+Calling skills invoke this skill via `Skill("commenting", args)` where `args` is a natural-language instruction. The commenting skill parses the intent and calls `save_comment` with proper formatting.
+
+### Anchor examples
+
+```
+Post an anchor comment on VID-123 titled "Assessment" from skill "pairprog" with body:
+
+**Clear and ready:**
+- Item 1
+- Item 2
+
+**Unclear:**
+- Question 1
+```
+
+```
+Post an anchor comment on VID-456 titled "Troubleshoot findings" from skill "troubleshoot" with body:
+
+**Root cause:**
+The config file is missing the API key entry.
+
+**Evidence:**
+- `src/config.ts:42` — reads `process.env.API_KEY` but `.env.example` doesn't list it
+```
+
+### Reply examples
+
+```
+Reply to anchor {comment-id} on VID-123 titled "Step 1 complete" from skill "pairprog" with body:
+
+Added OAuth callback route in `src/routes/auth.ts`.
+Test added — passing.
+Commit: `a1b2c3d`
+```
+
+```
+Reply to anchor {comment-id} on VID-123 titled "🚨 Plan adjusted" from skill "pairprog" with body:
+
+Step 3 replaced with Step 3a: explicit re-login flow.
+Reason: navigator decided silent refresh adds complexity.
+```
+
+### Resolution example
+
+```
+Reply to anchor {comment-id} on VID-123 titled "✅ Session complete" from skill "pairprog" with body:
+
+**Completed:**
+- [x] Step 1: OAuth callback route
+- [x] Step 2: Token storage
+
+**Remaining:**
+- (none — PR created: #47)
+```
+
+## Return value
+
+After posting, the skill returns the comment ID in chat so the calling skill can use it for threading:
+
+```
+Posted anchor comment {comment-id} on VID-123.
+```
+
+or
+
+```
+Posted reply to {parent-id} on VID-123.
+```
+
+The calling skill should store anchor IDs for the duration of its session to thread subsequent replies correctly.
+
+## Anti-patterns
+
+- **Don't post without a heading.** Every comment needs `**{Title}** ({skill})` on line 1.
+- **Don't skip provenance.** Every comment needs `*[ai:claude-code]*` on line 3.
+- **Don't post "starting X" comments.** Wait until X is done, then post findings. One comment per completed unit, not a running log.
+- **Don't interleave parallel results.** When multiple subagents complete, post one combined anchor rather than separate anchors that fragment the timeline.
+- **Don't use top-level comments for updates.** If an anchor exists for this unit of work, reply to it. Only create a new anchor for a genuinely new unit.
+- **Don't post empty resolution replies.** If there's nothing to say beyond "done", fold it into the last substantive reply with the ✅ prefix.

--- a/claude/skills/context7-mcp/SKILL.md
+++ b/claude/skills/context7-mcp/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: context7-mcp
+description: This skill should be used when the user asks about libraries, frameworks, API references, or needs code examples. Activates for setup questions, code generation involving libraries, or mentions of specific frameworks like React, Vue, Next.js, Prisma, Supabase, etc.
+---
+
+When the user asks about libraries, frameworks, or needs code examples, use Context7 to fetch current documentation instead of relying on training data.
+
+## When to Use This Skill
+
+Activate this skill when the user:
+
+- Asks setup or configuration questions ("How do I configure Next.js middleware?")
+- Requests code involving libraries ("Write a Prisma query for...")
+- Needs API references ("What are the Supabase auth methods?")
+- Mentions specific frameworks (React, Vue, Svelte, Express, Tailwind, etc.)
+
+## How to Fetch Documentation
+
+### Step 1: Resolve the Library ID
+
+Call `resolve-library-id` with:
+
+- `libraryName`: The library name extracted from the user's question
+- `query`: The user's full question (improves relevance ranking)
+
+### Step 2: Select the Best Match
+
+From the resolution results, choose based on:
+
+- Exact or closest name match to what the user asked for
+- Higher benchmark scores indicate better documentation quality
+- If the user mentioned a version (e.g., "React 19"), prefer version-specific IDs
+
+### Step 3: Fetch the Documentation
+
+Call `query-docs` with:
+
+- `libraryId`: The selected Context7 library ID (e.g., `/vercel/next.js`)
+- `query`: The user's specific question
+
+### Step 4: Use the Documentation
+
+Incorporate the fetched documentation into your response:
+
+- Answer the user's question using current, accurate information
+- Include relevant code examples from the docs
+- Cite the library version when relevant
+
+## Guidelines
+
+- **Be specific**: Pass the user's full question as the query for better results
+- **Version awareness**: When users mention versions ("Next.js 15", "React 19"), use version-specific library IDs if available from the resolution step
+- **Prefer official sources**: When multiple matches exist, prefer official/primary packages over community forks

--- a/claude/skills/linearissue/SKILL.md
+++ b/claude/skills/linearissue/SKILL.md
@@ -2,7 +2,7 @@
 name: linearissue
 description: "Use this skill when the user asks you to turn a design note's action items into Linear issues, OR when the user wants to iterate on an existing Linear issue. Filing mode triggers: 'file tickets from this note', 'linearize X', 'create Linear issues for the action items in X', 'turn this note into tickets', 'ship this to Linear', 'file these TODOs from the design note', 'make tickets from X', 'linearissue this note', 'create issues from X.md'. Iteration mode triggers: user passes a Linear issue URL (e.g. https://linear.app/...) or issue ID (e.g. VID-123) with a follow-on prompt like 'help me refine this', 'roast this scope', 'add context about X', 'what questions should we answer first', 'sharpen the description', or any request to think about, improve, or comment on an existing issue. Also trigger when the user invokes `/linearissue`. Do NOT trigger for creating Linear documents (that's the designnote skill's strategy-routing path), for filing tickets from `docs/decisions/` ADRs (decisions are made; they don't spawn tickets), or for any operation that would also commit to git."
 api_description: "File action items from a design note as Linear issues with bidirectional cross-references and idempotent re-runs, or iterate on an existing Linear issue by posting analysis, context, or refinements as comments. Two modes: filing (from a note) and iteration (from a ticket ID or URL)."
-allowed-tools: Bash Glob Grep Read Edit WebFetch AskUserQuestion mcp__claude_ai_Linear__list_issues mcp__claude_ai_Linear__get_issue mcp__claude_ai_Linear__save_issue mcp__claude_ai_Linear__list_comments mcp__claude_ai_Linear__save_comment mcp__claude_ai_Linear__list_teams mcp__claude_ai_Linear__get_team mcp__claude_ai_Linear__list_projects mcp__claude_ai_Linear__get_project mcp__claude_ai_Linear__list_issue_statuses mcp__claude_ai_Linear__list_issue_labels mcp__github__list_pull_requests mcp__github__pull_request_read mcp__github__search_pull_requests
+allowed-tools: Bash Glob Grep Read Edit WebFetch AskUserQuestion Skill mcp__claude_ai_Linear__list_issues mcp__claude_ai_Linear__get_issue mcp__claude_ai_Linear__save_issue mcp__claude_ai_Linear__list_comments mcp__claude_ai_Linear__list_teams mcp__claude_ai_Linear__get_team mcp__claude_ai_Linear__list_projects mcp__claude_ai_Linear__get_project mcp__claude_ai_Linear__list_issue_statuses mcp__claude_ai_Linear__list_issue_labels mcp__github__list_pull_requests mcp__github__pull_request_read mcp__github__search_pull_requests
 ---
 
 # linearissue
@@ -49,7 +49,8 @@ The human gate on the design note itself is where the real review happens. By th
 - `WebFetch` — follow URLs referenced in the note when enriching ticket descriptions
 - `AskUserQuestion` — the confirmation gate (and batched clarification if needed)
 - Linear MCP read tools — search for existing tickets, resolve teams/projects, look up statuses and labels
-- Linear MCP write tools — `save_issue`, `save_comment`
+- `Skill` — invoke the `commenting` skill for posting comments to Linear issues
+- Linear MCP write tools — `save_issue`
 
 The skill does not declare `Task` — there is no parallel research phase. Ticket derivation is deterministic and serial.
 
@@ -289,7 +290,7 @@ For mixed intents, address all of them in a single pass rather than asking for c
 
 Produce one or both of:
 
-1. **Comment draft** — the primary output in almost all cases. Write it as you would a thoughtful comment from a collaborator: direct, specific, actionable. Scope crystallization, analysis, questions, and context all belong here. Always open the comment with `*[ai:claude-code]*` so readers know before the content.
+1. **Comment draft** — the primary output in almost all cases. Write it as you would a thoughtful comment from a collaborator: direct, specific, actionable. Scope crystallization, analysis, questions, and context all belong here. (Provenance and formatting are handled by the commenting skill — do not add `*[ai:claude-code]*` manually.)
 2. **Anchor update** — only if the intent is explicitly to fix the title or description. Draft the new title and/or description. Keep to 2–4 sentences. Do not migrate comment-appropriate content into the description.
 
 Print both drafts in chat before asking for confirmation. Make it easy to scan.
@@ -306,7 +307,7 @@ On "Edit first": ask what to change, revise, re-present, confirm again.
 
 On approval, write in this order:
 1. `save_issue` for any title/description changes (only if confirmed)
-2. `save_comment` for the comment (only if confirmed)
+2. `Skill("commenting", ...)` to delegate the comment to the commenting skill (only if confirmed) — describe the issue ID, comment title (e.g. "Assessment", "Context", "Scope refinement"), the originating skill name ("linearissue"), and the comment body. The commenting skill handles formatting, provenance, and threading.
 
 ### Summary
 
@@ -350,4 +351,4 @@ The skill's `allowed-tools` declaration pre-approves the tool categories. For sc
 
 The skill checks for this grant in Phase 0 and warns if it's missing.
 
-Linear MCP write tools (`save_issue`, `save_comment`) are declared in `allowed-tools` and should not require per-call approval. If they do, the walk-away UX breaks — configure pre-approval before first use.
+Linear MCP write tool (`save_issue`) is declared in `allowed-tools` and should not require per-call approval. If it does, the walk-away UX breaks — configure pre-approval before first use. Comments are posted via `Skill("commenting", ...)`, which requires the `Skill` tool to be allowed so the commenting skill can be invoked.

--- a/claude/skills/pairprog/SKILL.md
+++ b/claude/skills/pairprog/SKILL.md
@@ -2,7 +2,7 @@
 name: pairprog
 description: "Use this skill when the user wants to pair-program on a ticket — working through a Linear issue collaboratively with the AI driving and the human navigating. Trigger for prompts like 'let's work on this ticket', 'pair on LIN-123', 'pairprog', 'let's tackle this branch', 'work on the current branch', 'pick up LIN-123', 'start working on this', 'let's pair on this'. Also trigger when the user invokes `/pairprog`. The skill reads the current branch (or a specified ticket/branch), looks up the Linear ticket, explores the codebase for context, identifies unknowns and feasibility risks, asks the human navigator for direction on key decisions, then executes the work in atomic steps with frequent HITL checkpoints. It uses concurrent subagents to parallelize independent exploration and implementation work. It comments assessments, spike findings, and plans back to the Linear ticket so context survives across sessions. In default mode, the human commits after reviewing each atomic change. In yolo mode, the skill auto-commits atomically and gates at PR creation. This is NOT a walk-away skill. It is an interactive pairing session where the human stays engaged as navigator. Do NOT trigger for autonomous background work (use designnote or direct implementation), for ticket creation (use linearissue), for research without implementation (use qsearch), or for commit message drafting (use commitmsg)."
 api_description: "Pair-program on a Linear ticket: explore the codebase, assess unknowns, spike on feasibility, plan atomic steps, and implement with frequent HITL checkpoints. Posts assessments, spike findings, and progress back to the Linear ticket. Human commits each step; AI drives."
-allowed-tools: Bash Glob Grep Read Write Edit Task Skill AskUserQuestion WebFetch mcp__claude_ai_Linear__get_issue mcp__claude_ai_Linear__list_issues mcp__claude_ai_Linear__list_comments mcp__claude_ai_Linear__save_comment mcp__claude_ai_Linear__save_issue mcp__claude_ai_Linear__list_teams mcp__claude_ai_Linear__get_team mcp__claude_ai_Linear__list_projects mcp__claude_ai_Linear__get_project mcp__claude_ai_Linear__list_issue_statuses mcp__claude_ai_Linear__list_issue_labels
+allowed-tools: Bash Glob Grep Read Write Edit Task Skill AskUserQuestion WebFetch mcp__claude_ai_Linear__get_issue mcp__claude_ai_Linear__list_issues mcp__claude_ai_Linear__list_comments mcp__claude_ai_Linear__save_issue mcp__claude_ai_Linear__list_teams mcp__claude_ai_Linear__get_team mcp__claude_ai_Linear__list_projects mcp__claude_ai_Linear__get_project mcp__claude_ai_Linear__list_issue_statuses mcp__claude_ai_Linear__list_issue_labels
 ---
 
 # pairprog
@@ -24,6 +24,8 @@ The defining design principles are:
 > **Parallel where possible.** Use subagents for independent exploration and implementation tasks. Don't serialize work that can run concurrently. But always reconvene with the navigator before acting on findings.
 >
 > **Comment everything back to the ticket.** Assessments, spike findings, plans, and step completions are posted as Linear comments. This means a cancelled session can be picked up later — the ticket carries the full context.
+
+**Commenting protocol.** All Linear comments are posted via the `commenting` skill (`Skill("commenting", ...)`). Pairprog describes what to comment; the commenting skill handles formatting, provenance, and threading. Store anchor comment IDs returned by the commenting skill to thread subsequent replies.
 
 ## Commit modes
 
@@ -170,19 +172,17 @@ Read the ticket and existing branch work. Categorize what remains:
 
 ### Comment the assessment to Linear
 
-Post a single comment to the ticket with the full assessment using `save_comment`:
+Post the assessment as an anchor comment via the commenting skill. Include the categorized unknowns (Clear and ready / Unclear / Feasibility unknowns / Blocked) as the body content:
 
-```markdown
-**Assessment** (pairprog)
-
-*[ai:claude-code]*
+```
+Skill("commenting", "Post an anchor comment on {ticket-id} titled \"Assessment\" from skill \"pairprog\" with body:
 
 **Clear and ready:**
 - Add Google OAuth callback endpoint
 - Store refresh tokens in existing session table
 
 **Unclear — need navigator input:**
-- Token expiry handling — ticket says "handle gracefully" but doesn't specify
+- Token expiry handling — ticket says \"handle gracefully\" but doesn't specify
 - Scope of Google permissions — email only, or also profile?
 
 **Feasibility unknowns — spiking:**
@@ -190,8 +190,10 @@ Post a single comment to the ticket with the full assessment using `save_comment
 - Session table schema — can we store tokens without a migration?
 
 **Blocked:**
-- (none)
+- (none)")
 ```
+
+Store the returned anchor comment ID — spike findings and other assessment follow-ups thread under it.
 
 ### Spike on feasibility (parallel)
 
@@ -203,12 +205,10 @@ For each feasibility unknown, spawn a `Task` subagent to investigate:
 
 Subagents are read-only investigators. They don't write production code.
 
-**Wait for all spikes to complete before commenting.** Don't post "starting spike" comments — post one consolidated findings comment per spike after the subagent returns:
+**Wait for all spikes to complete before commenting.** Don't post "starting spike" comments — post one consolidated findings anchor per spike after the subagent returns, via the commenting skill:
 
-```markdown
-**Spike: Google OAuth library compatibility** (pairprog)
-
-*[ai:claude-code]*
+```
+Skill("commenting", "Post an anchor comment on {ticket-id} titled \"Spike: Google OAuth library compatibility\" from skill \"pairprog\" with body:
 
 **Verdict:** Feasible ✓
 
@@ -216,7 +216,7 @@ Subagents are read-only investigators. They don't write production code.
 against our `tsconfig.json` paths — no conflicts. The `OAuth2Client` class exposes
 `getToken()` and `refreshToken()` which map directly to our needs.
 
-Relevant code: `src/config/auth.ts` already has a provider pattern we can extend.
+Relevant code: `src/config/auth.ts` already has a provider pattern we can extend.")
 ```
 
 ### Check in with the navigator
@@ -289,20 +289,18 @@ Wait for the navigator's approval or adjustment before proceeding.
 
 ### Comment the plan to Linear
 
-After the navigator approves (or adjusts) the plan, post it as a comment:
+After the navigator approves (or adjusts) the plan, post it as an anchor comment via the commenting skill:
 
-```markdown
-**Plan** (pairprog)
-
-*[ai:claude-code]*
+```
+Skill("commenting", "Post an anchor comment on {ticket-id} titled \"Plan\" from skill \"pairprog\" with body:
 
 - [ ] Step 1: Add Google OAuth callback route
 - [ ] Step 2: Token storage in session metadata (parallel with 3)
 - [ ] Step 3: Silent token refresh middleware (parallel with 2)
-- [ ] Step 4: Update login UI with Google button (after 1-3)
+- [ ] Step 4: Update login UI with Google button (after 1-3)")
 ```
 
-This checklist serves as the resumption point if the session is interrupted.
+Store the returned plan anchor comment ID — all step completions and mid-session adaptations thread under it. This checklist serves as the resumption point if the session is interrupted.
 
 ## Phase 3 — Execute
 
@@ -323,17 +321,15 @@ For each step:
 
 ### Comment step completions to Linear
 
-After each step is committed (by the navigator in checkpoint mode, or auto-committed in yolo mode), post a brief comment:
+After each step is committed (by the navigator in checkpoint mode, or auto-committed in yolo mode), post a reply threaded under the plan anchor via the commenting skill:
 
-```markdown
-**Step 1 complete** (pairprog)
-
-*[ai:claude-code]*
+```
+Skill("commenting", "Reply to anchor {plan-comment-id} on {ticket-id} titled \"Step 1 complete\" from skill \"pairprog\" with body:
 
 Added Google OAuth callback route in `src/routes/auth.ts` and `src/config/oauth.ts`.
 Test added in `src/routes/__tests__/auth.test.ts` — passing.
 
-Commit: `a1b2c3d`
+Commit: `a1b2c3d`")
 ```
 
 ### Parallel execution
@@ -358,15 +354,15 @@ Pair programming is fluid. The plan from Phase 2 is a starting point, not a cont
 
 Accommodate without friction. The navigator steers.
 
-When mid-session adaptation happens, comment the change to Linear with a recognizable marker:
+When mid-session adaptation happens, post the change as a reply to the plan anchor via the commenting skill. Use the appropriate emoji prefix in the title:
 
-```markdown
-🚨 **Plan adjusted** (pairprog)
+```
+Skill("commenting", "Reply to anchor {plan-comment-id} on {ticket-id} titled \"🚨 Plan adjusted\" from skill \"pairprog\" with body:
 
 Step 3 (Silent token refresh middleware) replaced with:
 Step 3a: Explicit re-login flow on token expiry
 
-Reason: Navigator decided silent refresh adds complexity without clear UX benefit.
+Reason: Navigator decided silent refresh adds complexity without clear UX benefit.")
 ```
 
 Use these emojis for mid-session events:
@@ -406,12 +402,10 @@ If the navigator says "not yet" or "more work needed," skip. The navigator will 
 
 ### Comment wrap-up to Linear
 
-Post a final session summary comment:
+Post a final session summary as a resolution reply to the plan anchor via the commenting skill:
 
-```markdown
-**Session complete** (pairprog)
-
-*[ai:claude-code]*
+```
+Skill("commenting", "Reply to anchor {plan-comment-id} on {ticket-id} titled \"✅ Session complete\" from skill \"pairprog\" with body:
 
 **Completed:**
 - [x] Step 1: OAuth callback route
@@ -422,7 +416,7 @@ Post a final session summary comment:
 **Remaining:**
 - (none — PR created: #47)
 
-**Commits:** a1b2c3d, d4e5f6a, b7c8d9e, f0a1b2c
+**Commits:** a1b2c3d, d4e5f6a, b7c8d9e, f0a1b2c")
 ```
 
 ## Anti-patterns

--- a/claude/skills/troubleshoot/SKILL.md
+++ b/claude/skills/troubleshoot/SKILL.md
@@ -2,7 +2,7 @@
 name: troubleshoot
 description: "Use this skill when the user wants to diagnose an error, investigate a failure, or root-cause a bug — without necessarily fixing it right away. Trigger for prompts like 'troubleshoot X', 'why is Y failing', 'debug this error', 'investigate LIN-123', 'figure out what's wrong with Z', 'look into this CI failure', 'root-cause this crash', or when the user invokes `/troubleshoot`. The skill is a walk-away investigator: it runs read-only commands, tees output to files, investigates in parallel via subagents, formulates a root-cause hypothesis, and confirms it with a minimal reproducible test — all with minimal interrupts so the operator can step away and return to a finished report. Findings are posted as Linear comments or design note updates depending on context. If a fix is needed after the diagnosis, the skill hands off to /pairprog. Do NOT trigger when the user wants to immediately implement a fix (use /pairprog), when pure web research suffices (use /qsearch), or when the issue is a design decision rather than a failure (use /designnote)."
 api_description: "Diagnose a failure autonomously: run read-only commands, investigate in parallel via subagents, formulate a root-cause hypothesis, confirm with a minimal repro, and post findings as a Linear comment or design note update. Walk-away investigation; hands off to pairprog if a fix is needed."
-allowed-tools: Bash Glob Grep Read Task AskUserQuestion WebSearch WebFetch mcp__claude_ai_Linear__get_issue mcp__claude_ai_Linear__list_issues mcp__claude_ai_Linear__list_comments mcp__claude_ai_Linear__save_comment mcp__claude_ai_Linear__get_document mcp__claude_ai_Linear__list_documents mcp__claude_ai_Linear__list_teams mcp__claude_ai_Linear__get_team mcp__claude_ai_Linear__list_projects mcp__claude_ai_Linear__get_project mcp__github__pull_request_read mcp__github__list_pull_requests mcp__github__get_commit mcp__github__list_commits mcp__github__search_code
+allowed-tools: Bash Glob Grep Read Task AskUserQuestion WebSearch WebFetch Skill mcp__claude_ai_Linear__get_issue mcp__claude_ai_Linear__list_issues mcp__claude_ai_Linear__list_comments mcp__claude_ai_Linear__get_document mcp__claude_ai_Linear__list_documents mcp__claude_ai_Linear__list_teams mcp__claude_ai_Linear__get_team mcp__claude_ai_Linear__list_projects mcp__claude_ai_Linear__get_project mcp__github__pull_request_read mcp__github__list_pull_requests mcp__github__get_commit mcp__github__list_commits mcp__github__search_code
 ---
 
 # troubleshoot
@@ -180,12 +180,10 @@ Wait for the operator's answer before writing anything to disk, posting any comm
 
 ### Persist on confirmation
 
-If the operator selects Linear comment, post:
+If the operator selects Linear comment, delegate to the commenting skill:
 
-```markdown
-**Troubleshoot findings** (troubleshoot)
-
-*[ai:claude-code]*
+```
+Skill("commenting", "Post an anchor comment on {TICKET-ID} titled \"Troubleshoot findings\" from skill \"troubleshoot\" with body:
 
 **Root cause:**
 <one-sentence hypothesis>
@@ -195,9 +193,9 @@ If the operator selects Linear comment, post:
 - <finding 2>
 
 **Reproduction:**
-```bash
+\`\`\`bash
 <minimal repro command>
-```
+\`\`\`
 Output: `troubleshoot-output/repro.txt`
 
 **Ruled out:**
@@ -206,10 +204,12 @@ Output: `troubleshoot-output/repro.txt`
 **Confidence:** high / medium / low — <reason>
 
 **Recommended next step:**
-<fix suggestion, or "needs human input on X before proceeding">
+<fix suggestion, or \"needs human input on X before proceeding\">
 
-**Investigation artifacts:** `troubleshoot-output/` (in working directory)
+**Investigation artifacts:** `troubleshoot-output/` (in working directory)")
 ```
+
+The commenting skill handles heading format, provenance markers, and threading. Do not format these yourself.
 
 If the operator selects design note update or local file, write the same content to the appropriate target.
 

--- a/configuration-darwin.nix
+++ b/configuration-darwin.nix
@@ -240,6 +240,7 @@ with lib;
       "claude"
       "anthropics/tap/ant"
       "superwhisper"
+      "granola"
       (if pkgs.stdenv.hostPlatform.system == "aarch64-darwin" then "chatgpt" else null)
     ];
     masApps = {

--- a/git/ignore
+++ b/git/ignore
@@ -6,7 +6,6 @@
 
 ### direnv ###
 .direnv
-.envrc
 
 ### Emacs ###
 # -*- mode: gitignore; -*-

--- a/home-darwin.nix
+++ b/home-darwin.nix
@@ -59,6 +59,7 @@
     pkgs.jq
     pkgs.yq
     pkgs.jless
+    pkgs.poppler-utils
     pkgs.sqlite-interactive
     pkgs.redis
     pkgs.fswatch


### PR DESCRIPTION
## Summary
- Add standalone `commenting` skill that owns the Linear commenting protocol: thread lifecycle (anchor → replies → resolution), provenance markers, formatting, and threading via `parentId`
- Refactor pairprog, troubleshoot, and linearissue to delegate all comment posting to the new skill instead of calling `save_comment` directly
- Skills now describe *what* to comment; the commenting skill handles *how*

## Test plan
- [ ] Commenting skill appears in Claude Code session skills list
- [ ] Pairprog session posts comments with correct formatting via commenting skill
- [ ] Troubleshoot findings post via commenting skill
- [ ] Linearissue iteration-mode comments post via commenting skill

[VID-663](https://linear.app/asabina/issue/VID-663/extract-commenting-skill-as-dry-protocol-for-all-skill-to-linear)

🤖 Generated with [Claude Code](https://claude.com/claude-code)