### PR TITLE
doc: align repo conventions to KB 2026-06-15 state [VID-687]

### DIFF
--- a/.github/workflows/lint-pr.yaml
+++ b/.github/workflows/lint-pr.yaml
@@ -1,0 +1,73 @@
+name: Lint PR
+
+# Why `pull_request` (not `pull_request_target`):
+#
+# The two triggers differ in which branch supplies the workflow file:
+#
+#   pull_request        → runs the workflow from the PR's HEAD branch
+#   pull_request_target → runs the workflow from the BASE branch (e.g. main)
+#
+# `pull_request_target` exists to protect repos that accept PRs from
+# forks. A forked PR using `pull_request` can modify the workflow to
+# exfiltrate repo secrets. `pull_request_target` prevents this by
+# ignoring the PR branch's workflow entirely — it always runs the base
+# branch copy. But this comes at a cost:
+#
+#   1. A workflow introduced in a PR won't run on that PR (the base
+#      branch doesn't have the file yet).
+#   2. Changes to an existing workflow are invisible on PRs — the base
+#      branch version runs, not yours. There is no partial pick-up.
+#   3. The only way to test workflow changes is to temporarily switch to
+#      `pull_request`, push, verify, then revert before merging.
+#
+# This repo is private with no fork contributions. The security benefit
+# of `pull_request_target` does not apply, and the testing friction is
+# pure cost. We use `pull_request` so workflow changes are testable on
+# the PRs that introduce them.
+#
+# If this repo ever accepts fork contributions, migrate to
+# `pull_request_target`:
+#   - Change `pull_request` → `pull_request_target` below
+#   - Accept that workflow changes require the test-revert dance above
+#   - Review GITHUB_TOKEN permissions (base branch context, not PR)
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+permissions:
+  pull-requests: read
+
+jobs:
+  validate-pr-title:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v6
+        with:
+          # Conventional commit types matching CONTRIBUTING.md
+          types: |
+            feat
+            fix
+            refactor
+            doc
+            test
+            chore
+            style
+            perf
+          # Ticket ID suffix is recommended but not required —
+          # ad-hoc branches without a ticket are valid.
+          subjectPattern: ^.+(\s\[[A-Z]+-\d+\])?$
+          subjectPatternError: |
+            The subject "{subject}" doesn't look right.
+            Expected format: type(scope): description [TICKET-ID]
+            Examples:
+              feat(auth): add OAuth callback [KB-31]
+              fix: handle null response [KB-45]
+              doc: update contributing guide
+            Ticket ID suffix is optional for branches without a ticket.
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -273,7 +273,15 @@ When the user asks to "sync skills", "update KB links", or when you notice a ski
 
 ## Commit message conventions
 
-- **Format:** `<type>(<scope>): <subject> [ai:claude]` — the `[ai:claude]` tag always goes at the end of the subject line for AI-authored commits
+> **Read `CONTRIBUTING.md` before drafting or making any commit.** It is the canonical source of truth for the commit format, AI co-authorship trailers, and PR title convention.
+
+Summary:
+
+- **Format:** `<type>(<scope>): <subject> [ai:<agent>]`
 - **No ticket ID in subject:** the branch name already encodes the ticket (e.g. `vidbina/vid-616-...`); don't repeat it in the commit subject
-- **Always include:** `Co-Authored-By: Claude Code <noreply@anthropic.com>` trailer in the commit body
+- **AI co-authorship:** always include both trailers (see CONTRIBUTING.md for details):
+  ```
+  Co-authored-by: Claude Code <noreply@anthropic.com>
+  Assisted-by: Claude:claude-opus-4-6
+  ```
 - **Commit via nix develop:** pre-commit hooks require tools only available in the dev shell — always use `nix develop --command git commit`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,9 @@
 # Contributing
 
+This document is the canonical source of truth for commit conventions, scope discipline, and contribution workflow. All contributors — human and AI — must follow these rules.
+
+> **For AI agents:** Read this file before drafting or making any commit. `AGENTS.md` defers to this file for commit format, the scope list, and prohibited patterns.
+
 ## Literate config and tangled files
 
 This repo uses a literate config approach. `README.org` is the canonical source for most nix configuration files. Org-babel tangles source blocks from `README.org` into their target files using noweb references.
@@ -44,7 +48,26 @@ Always run `make verify-parity` before committing changes that touch `README.org
 
 CI runs the same check, so commits with parity drift will fail.
 
-## AI Co-authorship
+## Commit Convention
+
+### Format
+
+```
+<type>(<scope>): <subject> [ai:<agent>]
+
+[optional body]
+
+[optional footer(s)]
+```
+
+- **type** — what kind of change (see table below)
+- **scope** — what area of the codebase is affected (see table below)
+- **subject** — imperative, lowercase, no period, ≤80 characters
+- **`[ai:<agent>]`** — required trailer when an AI agent authored or co-authored the commit (e.g. `[ai:claude]`, `[ai:gemini]`)
+- **body** — explain *why*, not *what* (the diff shows what)
+- **footer** — `Co-Authored-By:`, `BREAKING CHANGE:`, references
+
+### AI Co-authorship
 
 Use both trailers on every AI-assisted commit. `Co-authored-by` works with GitHub today; `Assisted-by` is the emerging standard but forges don't render it yet. Using both ensures nothing is lost as tooling catches up:
 
@@ -61,6 +84,116 @@ Once forges render `Assisted-by` natively, `Co-authored-by` can be dropped.
 
 Both trailers survive squash-merge in the commit body, so provenance is preserved even when individual commits are collapsed.
 
+### Types
+
+| Type | Use when… |
+|---|---|
+| `feat` | Adding a wholly new feature or capability |
+| `fix` | Fixing a bug |
+| `refactor` | Restructuring code without changing behavior |
+| `doc` | Documentation only |
+| `test` | Adding or updating tests only |
+| `chore` | Build, CI, tooling, dependencies |
+| `style` | Formatting, whitespace, lint fixes (no logic change) |
+| `perf` | Performance improvement |
+
+### Scopes
+
+| Scope | Covers |
+|---|---|
+| `nix` | Flake, nix-darwin modules, home-manager config, `README.org` source blocks |
+| `skills` | Claude Code skill definitions in `claude/skills/` |
+| `ci` | GitHub Actions workflows |
+
+> **Tip:** When no scope fits, omit it: `fix: handle null response from upstream`.
+> When a change genuinely spans multiple scopes, pick the primary one — do not concatenate (`nix+skills` is never valid).
+
+### Prohibited Scope Patterns
+
+These patterns are **never valid** as scopes. AI agents in particular tend to invent these — reject them in review.
+
+| Anti-pattern | Why it's wrong | Use instead |
+|---|---|---|
+| Ticket IDs (`VID-123`) | Scopes describe *what*, not *which task* | The correct canonical scope |
+| Pluralized duplicates (`tests`, `docs`) | Creates ambiguity with singular forms | `test`, `doc` |
+| Synonym drift (`flake` vs `nix`) | Fragments the log — pick one canonical name | The canonical scope from the table above |
+| Concatenated scopes (`nix+skills`) | One commit, one scope — split the commit or pick the primary | The primary scope |
+| Tool names (`gitleaks`, `emacs`) | Too granular — group by concern | `git`, `chore`, or `ci` |
+| File names (`flake.nix`) | Too specific, doesn't generalize | The area the file belongs to |
+
+### Subject Line Rules
+
+1. **Imperative mood:** "add feature" not "added feature" or "adding feature"
+2. **Lowercase:** no capital first letter
+3. **No period** at the end
+4. **≤80 characters** (enforced — see self-check below)
+5. **No ticket IDs** in the subject line — the branch name already encodes the ticket
+6. **Describe the change**, not the task: "add OAuth callback route" not "work on VID-123"
+
+#### Subject Line Self-Check Protocol
+
+This check is **not optional**. Run it before every commit:
+
+```bash
+echo -n "<type>(<scope>): <your subject> [ai:<agent>]" | wc -c
+```
+
+- If ≤80 → proceed
+- If >80 → shorten the subject, re-run, repeat until ≤80
+
+> **Why enforce this?** Long subjects wrap in `git log --oneline`, break notification previews, and make scanning history harder. The 80-char limit is a hard rule, not a suggestion.
+
+### BAD vs GOOD Examples
+
+```
+# BAD
+feat(shell): VID-123 add zsh completion for nix commands [ai:claude]   ← ticket ID in subject
+Fix: Added new package support.                                         ← past tense, capital, period
+feat(nix+skills): add cross-module config [ai:claude]                   ← concatenated scope
+refactor(flake): rename nix modules                                     ← synonym drift (use nix)
+
+# GOOD
+feat(shell): add zsh completion for nix commands [ai:claude]
+fix: handle missing flake input gracefully [ai:claude]
+refactor(nix): consolidate darwin module imports [ai:claude]
+doc: add literate config workflow to contributing guide [ai:claude]
+```
+
+## Pre-Commit Workflow
+
+1. **Complete your changes**
+2. **Run all quality checks** (formatting, linting, type checking, tests, build)
+3. **Fix any issues** that arise from quality checks
+4. **Stage specific files**: `git add <file1> <file2>` — never `git add .` or `git add -A` blindly, as this risks staging secrets, build artifacts, or unrelated changes
+5. **Run the subject line self-check** (see above)
+6. **Commit with proper message format**
+7. **Verify commit was signed**: `git log --show-signature -1`
+
+## Scope Discipline
+
+When working on a branch tied to a ticket, every change should fit the branch's stated purpose. Changes that don't fit fall into two categories:
+
+### Category A — Opportunistic Feature/Code Work
+
+Detected when a change touches files or functionality unrelated to the current branch's purpose (e.g. fixing an unrelated bug, adding a feature that belongs on a different ticket).
+
+**What to do:**
+
+- **Stop and surface it** before making the change
+- Options: (a) continue on the current branch if the team agrees, (b) cut a new branch, (c) file a ticket and defer
+- Never silently mix unrelated work into a branch — it makes review harder and reverts dangerous
+
+### Category B — Agent/Process Meta-Corrections
+
+Detected when a correction needs to be made to `AGENTS.md`, `CONTRIBUTING.md`, or other process documentation based on something learned during the current work.
+
+**What to do:**
+
+- Do it in place on the current branch — the correction must take effect immediately
+- Isolate in its own commit with a `doc:` subject so the PR diff shows the mixing explicitly
+
+**Why the distinction matters:** Category B corrections must take effect immediately — deferring them means working with broken instructions for the rest of the session. Category A has no such urgency and should always be routed properly.
+
 ## PR Title Convention
 
 PR titles follow the same conventional-commit format as individual commits, with a ticket ID suffix for traceability:
@@ -69,7 +202,7 @@ PR titles follow the same conventional-commit format as individual commits, with
 <type>(<scope>): <subject> [TICKET-ID]
 ```
 
-- **type** and **scope** — same rules as commits (see `AGENTS.md` commit conventions)
+- **type** and **scope** — same rules as commits (see tables above)
 - **subject** — imperative mood, value-oriented, distinguishing phrase first
 - **`[TICKET-ID]`** — the Linear ticket ID in square brackets, e.g. `[VID-31]`. Auto-injected from the branch name by the `/pr` skill. Omit only for ad-hoc branches without a ticket.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,3 +43,57 @@ Always run `make verify-parity` before committing changes that touch `README.org
 - You edited `README.org` but forgot to re-tangle (fix: run `make tangle`).
 
 CI runs the same check, so commits with parity drift will fail.
+
+## AI Co-authorship
+
+Use both trailers on every AI-assisted commit. `Co-authored-by` works with GitHub today; `Assisted-by` is the emerging standard but forges don't render it yet. Using both ensures nothing is lost as tooling catches up:
+
+```
+Co-authored-by: Claude Code <noreply@anthropic.com>
+Assisted-by: Claude:claude-opus-4-6
+```
+
+**`Co-authored-by:`** is the established Git/GitHub convention. GitHub renders it as a secondary author avatar on the commit. The email is a provenance marker, not a contact address — it follows GitHub's `noreply@` convention. Use `noreply@{provider-domain}` (e.g. `noreply@anthropic.com`, `noreply@openai.com`, `noreply@google.com`).
+
+**`Assisted-by:`** is the emerging standard from the [Linux kernel guidelines](https://github.com/torvalds/linux/blob/master/Documentation/process/coding-assistants.rst#attribution). Format: `AGENT_NAME:MODEL_VERSION`. No email field — sidesteps the fake-email problem. Not yet widely supported by forges, but forward-compatible.
+
+Once forges render `Assisted-by` natively, `Co-authored-by` can be dropped.
+
+Both trailers survive squash-merge in the commit body, so provenance is preserved even when individual commits are collapsed.
+
+## PR Title Convention
+
+PR titles follow the same conventional-commit format as individual commits, with a ticket ID suffix for traceability:
+
+```
+<type>(<scope>): <subject> [TICKET-ID]
+```
+
+- **type** and **scope** — same rules as commits (see `AGENTS.md` commit conventions)
+- **subject** — imperative mood, value-oriented, distinguishing phrase first
+- **`[TICKET-ID]`** — the Linear ticket ID in square brackets, e.g. `[VID-31]`. Auto-injected from the branch name by the `/pr` skill. Omit only for ad-hoc branches without a ticket.
+
+### Examples
+
+```
+feat(auth): enable Google login [VID-31]
+fix: handle null response from upstream [VID-45]
+doc: update contributing guide with PR title convention [VID-687]
+chore(ci): enforce semantic PR titles [VID-687]
+```
+
+### Why this format?
+
+Individual commits and merged PRs serve different audiences in `git log`:
+
+| Layer | Format | Ticket ID? | When visible |
+|---|---|---|---|
+| Individual commit | `type(scope): subject [ai:agent]` | No — branch encodes it | Always |
+| Merged PR (squash) | `type(scope): subject [TICKET-ID] (#N)` | Yes — for traceability | After squash-merge |
+| Merged PR (merge commit) | `type(scope): subject [TICKET-ID] (#N)` | Yes — on merge commit | After merge-commit |
+
+The ticket ID suffix is the visual signal that distinguishes a squash-merged PR from an individual commit when scanning `git log`. It also makes every merged PR traceable back to its Linear ticket without opening GitHub.
+
+### CI enforcement
+
+The `amannn/action-semantic-pull-request` GitHub Action validates PR titles on open/edit. See `.github/workflows/lint-pr.yaml`.


### PR DESCRIPTION
## Summary

- Expand CONTRIBUTING.md with full commit convention infrastructure: format,
  types/scopes tables, prohibited patterns, subject line rules, AI co-authorship
  dual-trailer (Co-authored-by + Assisted-by), PR title convention, pre-commit
  workflow, and scope discipline (Category A/B)
- Update AGENTS.md commit conventions to use generic `[ai:<agent>]` tag and
  defer to CONTRIBUTING.md as canonical source
- Add `lint-pr.yaml` workflow (amannn/action-semantic-pull-request) to enforce
  semantic PR titles in CI
- Add `.github-settings.yaml` declaring intended repo merge/protection settings
  for `/pr` skill drift detection

## Test plan

- [ ] Verify `lint-pr.yaml` fires on PR open (this PR itself is the test)
- [ ] Confirm CONTRIBUTING.md renders correctly on GitHub
- [ ] Manual: set squash-merge title source to "PR title" in GitHub Settings

https://linear.app/asabina/issue/VID-687

🤖 Generated with [Claude Code](https://claude.com/claude-code)