### PR TITLE
chore(nix): drop nightlight brew for native Night Shift [VID-691]

### DIFF
--- a/README.org
+++ b/README.org
@@ -3766,7 +3766,9 @@ Manual setup:
 1. Open Raycast Settings → Window Management
 2. Set *Gap* to *Small* (8 pt gaps work well; Tiny causes bottom-screen trimming when [[*JankyBorders][JankyBorders]] borders are active, because the border overlay adds ~5 px that Raycast's geometry doesn't account for)
 
-*** Nightlight
+*** COMMENT Nightlight
+
+Replaced by macOS native Night Shift (System Settings > Displays > Night Shift).
 
 #+begin_src nix :noweb-ref homebrew-brews :noweb yes
 "smudge/smudge/nightlight"

--- a/configuration-darwin.nix
+++ b/configuration-darwin.nix
@@ -195,7 +195,6 @@ with lib;
       "pidof"
       "usbutils"
       "pcalc"
-      "smudge/smudge/nightlight"
       "anomalyco/tap/opencode"
       "pi-coding-agent"
     ];


### PR DESCRIPTION
## Summary

- Remove `smudge/smudge/nightlight` homebrew formula — macOS ships Night Shift natively
- Eliminates untrusted tap warning from `nix-darwin-switch`

## Test plan

- [x] `make tangle` succeeds
- [x] `make verify-parity` passes
- [x] `make validate` — all nix checks pass
- [x] `make nix-darwin-switch` — nightlight warning gone

Stacked on #81 (VID-690). Merge order: #80 → #81 → this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)