### PR TITLE
chore: enable Figma MCP plugin [VID-681]

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -153,7 +153,8 @@
   },
   "enabledPlugins": {
     "obsidian@obsidian-skills": true,
-    "pyright-lsp@claude-plugins-official": true
+    "pyright-lsp@claude-plugins-official": true,
+    "figma@claude-plugins-official": true
   },
   "extraKnownMarketplaces": {
     "obsidian-skills": {


### PR DESCRIPTION
## Summary

- Enable the Figma plugin (`figma@claude-plugins-official`) in Claude Code settings
- Part of evaluating Figma MCP skills for design workflows from Claude

## Test plan

- [x] Plugin loads in Claude Code session
- [ ] Test `figma-use` write-to-canvas on a scratch file

[VID-681](https://linear.app/asabina/issue/VID-681/evaluate-figma-mcp-skills-for-design-workflows-from-claude)

🤖 Generated with [Claude Code](https://claude.com/claude-code)