### PR TITLE
feat(nix): enforce Linear app as default for linear:// URLs [VID-692]

### DIFF
--- a/README.org
+++ b/README.org
@@ -3255,6 +3255,14 @@ For MacOS, we just install pcalc using the brew:
 "pcalc"
 #+end_src
 
+**** duti
+
+The [[https://github.com/moretension/duti/][duti]] utility allows us to set default applications for document types and URL schemes on macOS from the CLI. We use it in a nix-darwin activation script to declaratively enforce app handlers on every =darwin-rebuild switch=.
+
+#+begin_src nix :noweb-ref homebrew-brews :noweb yes
+"duti"
+#+end_src
+
 *** Syncthing
 
 Navigate to [[http://localhost:8384/][Syncthing portal]] to configure your setup. As per [2022-05-05 Thu 12:08], the syncthing service in home-manager is only declarative to the extend of turning it on and providing extra CLI options to start the service with.

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -149,7 +149,7 @@
   },
   "statusLine": {
     "type": "command",
-    "command": "input=$(cat); cwd=$(echo \"$input\" | jq -r '.cwd'); branch=$(cd \"$cwd\" && git rev-parse --abbrev-ref HEAD 2>/dev/null || echo ''); ticket=$(echo \"$branch\" | grep -oiE '[A-Z]+-[0-9]+' | head -1 | tr '[:lower:]' '[:upper:]'); if [ -n \"$ticket\" ]; then printf '%b' \"\\e]8;;https://linear.app/asabina/issue/$ticket\\a$ticket\\e]8;;\\a | $cwd\"; else echo \"$cwd\"; fi"
+    "command": "input=$(cat); cwd=$(echo \"$input\" | jq -r '.cwd'); branch=$(cd \"$cwd\" && git rev-parse --abbrev-ref HEAD 2>/dev/null || echo ''); ticket=$(echo \"$branch\" | grep -oiE '[A-Z]+-[0-9]+' | head -1 | tr '[:lower:]' '[:upper:]'); if [ -n \"$ticket\" ]; then printf '%b' \"\\e]8;;linear://asabina/issue/$ticket\\a$ticket\\e]8;;\\a | $cwd\"; else echo \"$cwd\"; fi"
   },
   "enabledPlugins": {
     "obsidian@obsidian-skills": true,

--- a/configuration-darwin.nix
+++ b/configuration-darwin.nix
@@ -195,6 +195,7 @@ with lib;
       "pidof"
       "usbutils"
       "pcalc"
+      "duti"
       "anomalyco/tap/opencode"
       "pi-coding-agent"
     ];

--- a/system/darwin/default.nix
+++ b/system/darwin/default.nix
@@ -1,5 +1,6 @@
 { pkgs, lib, ... }: {
   imports = [
+    ./duti.nix
     ./wm.nix
   ];
 }

--- a/system/darwin/duti.nix
+++ b/system/darwin/duti.nix
@@ -1,0 +1,12 @@
+{ pkgs, lib, ... }: {
+  system.activationScripts.postActivation.text = lib.mkAfter ''
+    # Enforce default app handlers via duti
+    # URL schemes (2 args: bundle-id scheme)
+    if command -v duti &>/dev/null; then
+      echo "Setting default app handlers via duti..."
+      duti -s com.linear linear
+    else
+      echo "duti not found — skipping default app handler setup"
+    fi
+  '';
+}

--- a/system/darwin/duti.nix
+++ b/system/darwin/duti.nix
@@ -2,11 +2,12 @@
   system.activationScripts.postActivation.text = lib.mkAfter ''
     # Enforce default app handlers via duti
     # URL schemes (2 args: bundle-id scheme)
-    if command -v duti &>/dev/null; then
+    DUTI="/opt/homebrew/bin/duti"
+    if [ -x "$DUTI" ]; then
       echo "Setting default app handlers via duti..."
-      duti -s com.linear linear
+      "$DUTI" -s com.linear linear
     else
-      echo "duti not found — skipping default app handler setup"
+      echo "duti not found at $DUTI — skipping default app handler setup"
     fi
   '';
 }


### PR DESCRIPTION
## Summary

- Add `duti` to homebrew brews and create `system/darwin/duti.nix` activation script
  that runs `duti -s com.linear linear` on every `darwin-rebuild switch`
- Switch Claude Code status line ticket links from `https://linear.app/` to `linear://`
  so clicking opens the Linear desktop app directly

## Test plan

- [x] `make validate` passes
- [x] `make nix-darwin-switch` runs duti successfully
- [x] `duti -d linear` returns `com.linear`
- [x] `open "linear://asabina/issue/VID-692"` opens in Linear app

[VID-692](https://linear.app/asabina/issue/VID-692/enforce-default-app-handlers-via-duti-on-darwin)

🤖 Generated with [Claude Code](https://claude.com/claude-code)