### PR TITLE
feat(nix): enable Touch ID-free commit and push for remote sessions [VID-693]

### DIFF
--- a/README.org
+++ b/README.org
@@ -2272,6 +2272,7 @@ alias = {
   # Touch ID-free aliases for remote/agent sessions
   mcommit = "-c commit.gpgsign=false commit";
   mpush = "!git -c url.\"https://github.com/\".pushInsteadOf=\"git@github.com:\" push \"$@\" #";
+  mpull = "!git -c url.\"https://github.com/\".insteadOf=\"git@github.com:\" pull \"$@\" #";
 };
 #+end_src
 

--- a/README.org
+++ b/README.org
@@ -5522,6 +5522,12 @@ We also track our Claude settings file such that we can reproduce our setup rela
 ".claude/settings.json".source = config.lib.file.mkOutOfStoreSymlink "${dotfilesPath}/claude/settings.json";
 #+end_src
 
+Global Claude rules (=~/.claude/rules/=) are personal behavioral guidance that applies across all projects on this machine. Tracked here so they survive machine rebuilds.
+
+#+begin_src nix :noweb-ref home-darwin-home-file
+".claude/rules".source = config.lib.file.mkOutOfStoreSymlink "${dotfilesPath}/claude/rules";
+#+end_src
+
 #+begin_quote org
 [!WARNING]
 Pay attention to what ends up making its way to =~/.claude/settings.json= as you don't ever want secrets to make it into this repo.

--- a/README.org
+++ b/README.org
@@ -2269,6 +2269,9 @@ alias = {
   wdiff = "diff --word-diff --word-diff-regex='\\w+'";
   glog = "!git log --graph --all --format='%C(auto)%h %s%d' --color=always \"$@\" | gref-dedup | less -RF #";
   ready = "!git checkout main && git pull --ff-only";
+  # Touch ID-free aliases for remote/agent sessions
+  mcommit = "-c commit.gpgsign=false commit";
+  mpush = "!git -c url.\"https://github.com/\".pushInsteadOf=\"git@github.com:\" push \"$@\" #";
 };
 #+end_src
 

--- a/claude/rules/context7.md
+++ b/claude/rules/context7.md
@@ -1,0 +1,10 @@
+Use Context7 MCP to fetch current documentation whenever the user asks about a library, framework, SDK, API, CLI tool, or cloud service -- even well-known ones like React, Next.js, Prisma, Express, Tailwind, Django, or Spring Boot. This includes API syntax, configuration, version migration, library-specific debugging, setup instructions, and CLI tool usage. Use even when you think you know the answer -- your training data may not reflect recent changes. Prefer this over web search for library docs.
+
+Do not use for: refactoring, writing scripts from scratch, debugging business logic, code review, or general programming concepts.
+
+## Steps
+
+1. Always start with `resolve-library-id` using the library name and the user's question, unless the user provides an exact library ID in `/org/project` format
+2. Pick the best match (ID format: `/org/project`) by: exact name match, description relevance, code snippet count, source reputation (High/Medium preferred), and benchmark score (higher is better). If results don't look right, try alternate names or queries (e.g., "next.js" not "nextjs", or rephrase the question). Use version-specific IDs when the user mentions a version
+3. `query-docs` with the selected library ID and the user's full question (not single words)
+4. Answer using the fetched docs

--- a/claude/rules/remote-commits.md
+++ b/claude/rules/remote-commits.md
@@ -1,0 +1,8 @@
+When Touch ID is unavailable (remote-control sessions, walk-away agents, SSH sessions), use these git aliases instead of the standard commands:
+
+- `git mcommit` instead of `git commit` — skips SSH signing. Commits will show as "Unverified" on GitHub, which is the intended signal for AI-produced work.
+- `git mpush` instead of `git push` — routes through HTTPS via `gh` auth token instead of SSH/1Password.
+
+Both aliases are defined in the dotfiles nix config and available on all machines managed by this setup.
+
+When working locally with Touch ID available, use the normal `git commit` and `git push` — signed commits are preferred for human-reviewed work.

--- a/claude/rules/remote-commits.md
+++ b/claude/rules/remote-commits.md
@@ -2,7 +2,8 @@ When Touch ID is unavailable (remote-control sessions, walk-away agents, SSH ses
 
 - `git mcommit` instead of `git commit` — skips SSH signing. Commits will show as "Unverified" on GitHub, which is the intended signal for AI-produced work.
 - `git mpush` instead of `git push` — routes through HTTPS via `gh` auth token instead of SSH/1Password.
+- `git mpull` instead of `git pull` — fetches through HTTPS via `gh` auth token instead of SSH/1Password.
 
-Both aliases are defined in the dotfiles nix config and available on all machines managed by this setup.
+All aliases are defined in the dotfiles nix config and available on all machines managed by this setup.
 
-When working locally with Touch ID available, use the normal `git commit` and `git push` — signed commits are preferred for human-reviewed work.
+When working locally with Touch ID available, use the normal `git commit`, `git push`, and `git pull` — signed commits are preferred for human-reviewed work.

--- a/home-darwin.nix
+++ b/home-darwin.nix
@@ -164,6 +164,7 @@
           # Touch ID-free aliases for remote/agent sessions
           mcommit = "-c commit.gpgsign=false commit";
           mpush = "!git -c url.\"https://github.com/\".pushInsteadOf=\"git@github.com:\" push \"$@\" #";
+          mpull = "!git -c url.\"https://github.com/\".insteadOf=\"git@github.com:\" pull \"$@\" #";
         };
         init = {
           defaultBranch = "main";

--- a/home-darwin.nix
+++ b/home-darwin.nix
@@ -89,6 +89,7 @@
     ".hammerspoon".source = config.lib.file.mkOutOfStoreSymlink ./hammerspoon;
     ".claude/skills".source = config.lib.file.mkOutOfStoreSymlink "${dotfilesPath}/claude/skills";
     ".claude/settings.json".source = config.lib.file.mkOutOfStoreSymlink "${dotfilesPath}/claude/settings.json";
+    ".claude/rules".source = config.lib.file.mkOutOfStoreSymlink "${dotfilesPath}/claude/rules";
   };
   programs.vscode = {
     enable = true;

--- a/home-darwin.nix
+++ b/home-darwin.nix
@@ -160,6 +160,9 @@
           wdiff = "diff --word-diff --word-diff-regex='\\w+'";
           glog = "!git log --graph --all --format='%C(auto)%h %s%d' --color=always \"$@\" | gref-dedup | less -RF #";
           ready = "!git checkout main && git pull --ff-only";
+          # Touch ID-free aliases for remote/agent sessions
+          mcommit = "-c commit.gpgsign=false commit";
+          mpush = "!git -c url.\"https://github.com/\".pushInsteadOf=\"git@github.com:\" push \"$@\" #";
         };
         init = {
           defaultBranch = "main";


### PR DESCRIPTION
## Summary

- Add `git mcommit` alias — commits without SSH signing (`-c commit.gpgsign=false`). Commits show as "Unverified" on GitHub, which is the intended signal for AI-produced work.
- Add `git mpush` alias — pushes via HTTPS using `gh` auth token instead of SSH/1Password. No Touch ID required.
- Track `claude/rules/` in dotfiles with `mkOutOfStoreSymlink` to `~/.claude/rules/`
- Add `remote-commits.md` rule instructing agents to use `mcommit`/`mpush` when Touch ID is unavailable

Supersedes VID-639 (machine signing key approach retired — it would have made AI commits look verified, removing the audit signal).

## Test plan

- [x] `git mcommit` commits without Touch ID prompt
- [x] `git mpush` pushes via HTTPS without Touch ID prompt
- [x] Full remote-control flow verified: both aliases used to commit and push this PR itself
- [x] `make validate` passes

[VID-693](https://linear.app/asabina/issue/VID-693/enable-touch-id-free-commit-and-push-for-remote-sessions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)