### PR TITLE
doc: add merge strategy section and merge-hygiene rule [VID-649]

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -288,6 +288,10 @@ When the user asks to "sync skills", "update KB links", or when you notice a ski
 - **Non-KB symlinks** (e.g. `techddreport` → a different repo): left untouched. These are one-off arrangements.
 - **Creating the `kb` symlink itself:** that's a human setup step (`ln -s /path/to/kb-repo kb`).
 
+## Merge strategy
+
+Merge via `/pr` — it reads the repo's merge convention from CONTRIBUTING.md and `.github-settings.yaml`, handles stack-aware retargeting, and checks for child PRs before deleting branches. Do not merge from the GitHub web UI for stacked PRs.
+
 ## Commit message conventions
 
 > **Read `CONTRIBUTING.md` before drafting or making any commit.** It is the canonical source of truth for the commit format, AI co-authorship trailers, and PR title convention.

--- a/claude/rules/merge-hygiene.md
+++ b/claude/rules/merge-hygiene.md
@@ -1,0 +1,3 @@
+Before merging any PR, verify its base branch is correct — never assume. For stacked PRs, check that child PRs have been retargeted before deleting the merged branch.
+
+Use `/pr` for all merges. It reads the repo's merge convention, handles stack ordering, and checks for child PRs automatically. Do not merge from the GitHub web UI for stacked PRs — it doesn't enforce retargeting.


### PR DESCRIPTION
## Summary

- Add merge strategy section to AGENTS.md — minimal pointer to `/pr` skill for merge convention, no specific merge method prescribed (that's per-repo, read from CONTRIBUTING.md / .github-settings.yaml by the skill)
- Add `claude/rules/merge-hygiene.md` — global rule: verify base branches before merging, use `/pr` for stack-aware discipline

## Test plan

- [x] AGENTS.md merge section doesn't prescribe a specific merge method
- [x] Rule is methodology-focused, not implementation-specific
- [ ] Verify rule is picked up in new Claude sessions

[VID-649](https://linear.app/asabina/issue/VID-649/document-merge-strategy-in-agentsmd)

🤖 Generated with [Claude Code](https://claude.com/claude-code)