### PR TITLE
feat(nix): move claude-code from nixpkgs to Homebrew cask

### DIFF
--- a/README.org
+++ b/README.org
@@ -1583,6 +1583,11 @@ with lib;
     ./system/darwin
   ];
 
+  # Disable manual generation — nix-darwin's --toc-depth flag is incompatible
+  # with the nixos-render-docs version in nixpkgs-unstable as of July 2026.
+  # Track upstream fix: nix-darwin needs to use --sidebar-depth instead.
+  documentation.enable = false;
+
   # List packages installed in system profile. To search by name, run:
   # $ nix-env -qaP | grep wget
   environment.systemPackages = with pkgs; [

--- a/README.org
+++ b/README.org
@@ -5485,15 +5485,11 @@ https://apps.apple.com/de/app/amphetamine/id937984704?l=en-GB&mt=12b
 
 **** Claude Code
 
-See [[https://www.npmjs.com/package/@anthropic-ai/claude-code][NPM]] or [[https://github.com/anthropics/claude-code][GitHub]] for the Claude Code CLI tool which is in research preview as per <2025-05-22 Thu>.
+See [[https://www.npmjs.com/package/@anthropic-ai/claude-code][NPM]] or [[https://github.com/anthropics/claude-code][GitHub]] for the Claude Code CLI tool.
 
-#+begin_src nix :noweb-ref dev-packages
-pkgs.claude-code
-#+end_src
+Installed via Homebrew cask rather than nixpkgs. Claude Code's release cadence (~90 versions between nixpkgs-unstable and upstream as of <2026-07-06 Sun>) makes nixpkgs impractical — features like model selection (Fable requires ≥2.1.170) ship weeks before nixpkgs catches up. Homebrew tracks upstream closely (91K installs/month) and the =claude-code= cask is maintained by the community.
 
-Note that claude-code is unfree.
-
-#+begin_src nix :noweb-ref darwin-unfree
+#+begin_src nix :noweb-ref homebrew-casks :noweb yes
 "claude-code"
 #+end_src
 

--- a/README.org
+++ b/README.org
@@ -1583,11 +1583,6 @@ with lib;
     ./system/darwin
   ];
 
-  # Disable manual generation — nix-darwin's --toc-depth flag is incompatible
-  # with the nixos-render-docs version in nixpkgs-unstable as of July 2026.
-  # Track upstream fix: nix-darwin needs to use --sidebar-depth instead.
-  documentation.enable = false;
-
   # List packages installed in system profile. To search by name, run:
   # $ nix-env -qaP | grep wget
   environment.systemPackages = with pkgs; [
@@ -1970,13 +1965,14 @@ nixpkgs.config.allowUnfreePredicate = pkg: builtins.elem (lib.getName pkg) [
 ];
 #+end_src
 
-**** Allow some nixpkgs overlays inn nix-darwin
+**** Allow some nixpkgs overlays in nix-darwin
 
 #+begin_src nix :noweb-ref nix-darwin :noweb yes
 nixpkgs.overlays = [
   <<darwin-overlays>>
 ];
 #+end_src
+
 
 ** Editors
 *** VsCode

--- a/configuration-darwin.nix
+++ b/configuration-darwin.nix
@@ -9,6 +9,11 @@ with lib;
     ./system/darwin
   ];
 
+  # Disable manual generation — nix-darwin's --toc-depth flag is incompatible
+  # with the nixos-render-docs version in nixpkgs-unstable as of July 2026.
+  # Track upstream fix: nix-darwin needs to use --sidebar-depth instead.
+  documentation.enable = false;
+
   # List packages installed in system profile. To search by name, run:
   # $ nix-env -qaP | grep wget
   environment.systemPackages = with pkgs; [

--- a/configuration-darwin.nix
+++ b/configuration-darwin.nix
@@ -9,11 +9,6 @@ with lib;
     ./system/darwin
   ];
 
-  # Disable manual generation — nix-darwin's --toc-depth flag is incompatible
-  # with the nixos-render-docs version in nixpkgs-unstable as of July 2026.
-  # Track upstream fix: nix-darwin needs to use --sidebar-depth instead.
-  documentation.enable = false;
-
   # List packages installed in system profile. To search by name, run:
   # $ nix-env -qaP | grep wget
   environment.systemPackages = with pkgs; [

--- a/configuration-darwin.nix
+++ b/configuration-darwin.nix
@@ -243,6 +243,7 @@ with lib;
       "obsidian" # best-in-class with mobile app support
       "linear"
       "claude"
+      "claude-code"
       "anthropics/tap/ant"
       "superwhisper"
       "granola"
@@ -262,7 +263,6 @@ with lib;
 
   nixpkgs.config.allowUnfreePredicate = pkg: builtins.elem (lib.getName pkg) [
     "vscode"
-    "claude-code"
   ];
 
   nixpkgs.overlays = [

--- a/flake.lock
+++ b/flake.lock
@@ -515,17 +515,16 @@
     "git-hooks_4": {
       "inputs": {
         "flake-compat": "flake-compat_5",
-        "gitignore": "gitignore_6",
         "nixpkgs": [
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1776796298,
-        "narHash": "sha256-PcRvlWayisPSjd0UcRQbhG8Oqw78AcPE6x872cPRHN8=",
+        "lastModified": 1783008725,
+        "narHash": "sha256-jGiy6+sxjNWXSjp25uoJuNfyH9zBK1PEDY0lVoL4ibQ=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "3cfd774b0a530725a077e17354fbdb87ea1c4aad",
+        "rev": "bca82caa46d5ec0f5d422c61fb1e30bc51313cbe",
         "type": "github"
       },
       "original": {
@@ -652,27 +651,6 @@
         "type": "github"
       }
     },
-    "gitignore_6": {
-      "inputs": {
-        "nixpkgs": [
-          "git-hooks",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1709087332,
-        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "type": "github"
-      }
-    },
     "home-manager": {
       "inputs": {
         "nixpkgs": [
@@ -702,11 +680,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776184304,
-        "narHash": "sha256-No6QGBmIv5ChiwKCcbkxjdEQ/RO2ZS1gD7SFy6EZ7rc=",
+        "lastModified": 1783222121,
+        "narHash": "sha256-E/ElL373TO8lQ2aMvYyzN+k4xkVaUGoRqoa8AtM71tI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "3c7524c68348ef79ce48308e0978611a050089b2",
+        "rev": "a1645f40777620c4bd2b6d854b290c2fc354a266",
         "type": "github"
       },
       "original": {
@@ -784,11 +762,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1770922915,
-        "narHash": "sha256-6J/JoK9iL7sHvKJcGW2KId2agaKv1OGypsa7kN+ZBD4=",
+        "lastModified": 1781761792,
+        "narHash": "sha256-rCPytmKNjctLloB6UgK5CRrHSwV4b0ygxtJLPPp8R14=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "6c5a56295d2a24e43bcd8af838def1b9a95746b2",
+        "rev": "a1fa429e945becaf60468600daf649be4ba0350c",
         "type": "github"
       },
       "original": {
@@ -964,11 +942,11 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1776255774,
-        "narHash": "sha256-psVTpH6PK3q1htMJpmdz1hLF5pQgEshu7gQWgKO6t6Y=",
+        "lastModified": 1783279667,
+        "narHash": "sha256-/NAkDSsve+GNM0Bt6tleJdCGfsTlK89nPjkVOzZMo0s=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "566acc07c54dc807f91625bb286cb9b321b5f42a",
+        "rev": "f205b5574fd0cb7da5b702a2da51507b7f4fdd1b",
         "type": "github"
       },
       "original": {
@@ -1144,11 +1122,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1771296295,
-        "narHash": "sha256-nm8qOdnVz/4C/WlmYQkvBXWn+TxlTxPPmUYyN3duLu0=",
+        "lastModified": 1783310592,
+        "narHash": "sha256-BgUENdi4wzlftAjjfKDyq9jxdZK2c41cp23gsK88bJg=",
         "owner": "nix-community",
         "repo": "nix-vscode-extensions",
-        "rev": "b82f1bb23901ac24bf973a4a3cbddf5857245c09",
+        "rev": "aa655f11c8df5f520aeeb106ea464519ec2d300a",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -515,16 +515,17 @@
     "git-hooks_4": {
       "inputs": {
         "flake-compat": "flake-compat_5",
+        "gitignore": "gitignore_6",
         "nixpkgs": [
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1783008725,
-        "narHash": "sha256-jGiy6+sxjNWXSjp25uoJuNfyH9zBK1PEDY0lVoL4ibQ=",
+        "lastModified": 1776796298,
+        "narHash": "sha256-PcRvlWayisPSjd0UcRQbhG8Oqw78AcPE6x872cPRHN8=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "bca82caa46d5ec0f5d422c61fb1e30bc51313cbe",
+        "rev": "3cfd774b0a530725a077e17354fbdb87ea1c4aad",
         "type": "github"
       },
       "original": {
@@ -651,6 +652,27 @@
         "type": "github"
       }
     },
+    "gitignore_6": {
+      "inputs": {
+        "nixpkgs": [
+          "git-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
     "home-manager": {
       "inputs": {
         "nixpkgs": [
@@ -680,11 +702,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783222121,
-        "narHash": "sha256-E/ElL373TO8lQ2aMvYyzN+k4xkVaUGoRqoa8AtM71tI=",
+        "lastModified": 1776184304,
+        "narHash": "sha256-No6QGBmIv5ChiwKCcbkxjdEQ/RO2ZS1gD7SFy6EZ7rc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "a1645f40777620c4bd2b6d854b290c2fc354a266",
+        "rev": "3c7524c68348ef79ce48308e0978611a050089b2",
         "type": "github"
       },
       "original": {
@@ -762,11 +784,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781761792,
-        "narHash": "sha256-rCPytmKNjctLloB6UgK5CRrHSwV4b0ygxtJLPPp8R14=",
+        "lastModified": 1770922915,
+        "narHash": "sha256-6J/JoK9iL7sHvKJcGW2KId2agaKv1OGypsa7kN+ZBD4=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "a1fa429e945becaf60468600daf649be4ba0350c",
+        "rev": "6c5a56295d2a24e43bcd8af838def1b9a95746b2",
         "type": "github"
       },
       "original": {
@@ -942,11 +964,11 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1783279667,
-        "narHash": "sha256-/NAkDSsve+GNM0Bt6tleJdCGfsTlK89nPjkVOzZMo0s=",
+        "lastModified": 1776255774,
+        "narHash": "sha256-psVTpH6PK3q1htMJpmdz1hLF5pQgEshu7gQWgKO6t6Y=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f205b5574fd0cb7da5b702a2da51507b7f4fdd1b",
+        "rev": "566acc07c54dc807f91625bb286cb9b321b5f42a",
         "type": "github"
       },
       "original": {
@@ -1122,11 +1144,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783310592,
-        "narHash": "sha256-BgUENdi4wzlftAjjfKDyq9jxdZK2c41cp23gsK88bJg=",
+        "lastModified": 1771296295,
+        "narHash": "sha256-nm8qOdnVz/4C/WlmYQkvBXWn+TxlTxPPmUYyN3duLu0=",
         "owner": "nix-community",
         "repo": "nix-vscode-extensions",
-        "rev": "aa655f11c8df5f520aeeb106ea464519ec2d300a",
+        "rev": "b82f1bb23901ac24bf973a4a3cbddf5857245c09",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -64,7 +64,7 @@
           ++ machine.extraModules;
         };
     in
-    flake-utils.lib.eachSystem [ "x86_64-darwin" "aarch64-darwin" ] (
+    flake-utils.lib.eachSystem [ "aarch64-darwin" ] (
       system:
       let
         pkgs = nixpkgs.legacyPackages.${system};

--- a/home-darwin.nix
+++ b/home-darwin.nix
@@ -63,7 +63,6 @@
     pkgs.sqlite-interactive
     pkgs.redis
     pkgs.fswatch
-    pkgs.claude-code
     pkgs.gemini-cli
     pkgs.codex
     pkgs.ollama


### PR DESCRIPTION
## Summary
- Move claude-code from `pkgs.claude-code` (nixpkgs, stuck at 2.1.104) to Homebrew cask (2.1.193). Nixpkgs-unstable lags ~90 versions behind upstream — features like Fable model selection (≥2.1.170) are unavailable for weeks after release.
- Drop x86_64-darwin from flake eachSystem (no x86 machines in use).
- Typo fix in README.org overlay section heading.

Note: branch also contains reverted flake input updates and documentation workaround attempts — these net to zero in the final diff. Squash-merge produces a clean commit.

## Test plan
- [x] `make nix-darwin-switch` succeeds
- [x] `claude --version` shows 2.1.193+ (Homebrew-installed)
- [x] `/model` picker in Claude Code shows Fable

🤖 Generated with [Claude Code](https://claude.com/claude-code)