### PR TITLE
feat: enable Claude Code push notifications and add Figma MCP to OpenCode

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -167,5 +167,6 @@
   },
   "editorMode": "vim",
   "preferredNotifChannel": "ghostty",
-  "model": "claude-fable-5[1m]"
+  "inputNeededNotifEnabled": true,
+  "agentPushNotifEnabled": true
 }

--- a/opencode/opencode.jsonc
+++ b/opencode/opencode.jsonc
@@ -5,6 +5,10 @@
       "type": "remote",
       "url": "https://connect.composio.dev/mcp",
       "oauth": {}
+    },
+    "figma": {
+      "type": "remote",
+      "url": "http://127.0.0.1:3845/mcp"
     }
   }
 }


### PR DESCRIPTION
## Summary
- Enable `inputNeededNotifEnabled` and `agentPushNotifEnabled` in Claude settings, drop stale model override
- Add Figma MCP server to OpenCode config

## Test plan
- [ ] Verify Claude push notifications work after nix-darwin-switch
- [ ] Verify OpenCode picks up the Figma MCP server

🤖 Generated with [Claude Code](https://claude.com/claude-code)