### PR TITLE
feat(dispatch): extract dispatch results via tested Python script [VID-698]

### DIFF
--- a/.github/workflows/skill-tests.yml
+++ b/.github/workflows/skill-tests.yml
@@ -1,0 +1,48 @@
+name: Skill Tests
+
+# Uses dorny/paths-filter so the job always appears on PRs — either running
+# or reporting "skipped". This satisfies branch protection's required status
+# checks regardless of which files changed.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            skills:
+              - 'claude/skills/**/scripts/**'
+              - 'claude/skills/**/tests/**'
+              - 'claude/skills/**/pyproject.toml'
+              - '.github/workflows/skill-tests.yml'
+
+      - uses: astral-sh/setup-uv@v6
+        if: steps.filter.outputs.skills == 'true'
+
+      - name: Discover and test skills
+        if: steps.filter.outputs.skills == 'true'
+        run: |
+          exit_code=0
+          for pyproject in claude/skills/*/pyproject.toml; do
+            skill_dir="$(dirname "$pyproject")"
+            test_dir="$skill_dir/tests"
+            if [ -d "$test_dir" ]; then
+              echo "::group::Testing $skill_dir"
+              (cd "$skill_dir" && uv run pytest tests/ -v) || exit_code=1
+              echo "::endgroup::"
+            fi
+          done
+          exit $exit_code

--- a/claude/skills/dispatch/.gitignore
+++ b/claude/skills/dispatch/.gitignore
@@ -1,0 +1,2 @@
+.venv/
+.pytest_cache/

--- a/claude/skills/dispatch/pyproject.toml
+++ b/claude/skills/dispatch/pyproject.toml
@@ -1,0 +1,11 @@
+[project]
+name = "dispatch-skill"
+version = "0.1.0"
+description = "Dispatch skill scripts — managed agent session extraction"
+requires-python = ">=3.11"
+
+[dependency-groups]
+dev = ["pytest>=8.0"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/claude/skills/dispatch/scripts/dispatch_gather.py
+++ b/claude/skills/dispatch/scripts/dispatch_gather.py
@@ -1,0 +1,499 @@
+#!/usr/bin/env python3
+"""Extract results from dispatch managed agent sessions.
+
+Reads NDJSON event streams from `ant beta:sessions:events list`, extracts
+agent.message text, validates byte counts, writes markdown output files with
+YAML frontmatter, and atomically updates the run file.
+
+Designed for agentic use: structured JSON output on stdout, diagnostics on
+stderr, meaningful exit codes.
+"""
+
+import argparse
+import json
+import os
+import re
+import sys
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+# Exit codes
+EXIT_OK = 0
+EXIT_PARTIAL = 1        # some sessions had low byte counts
+EXIT_BAD_INPUT = 2      # invalid input (missing file, bad JSON)
+EXIT_NO_EVENTS = 3      # no events file provided or found
+
+MIN_BYTES_THRESHOLD = 500
+
+
+def parse_ndjson(source):
+    """Parse NDJSON (or pretty-printed concatenated JSON) from a file path or
+    stdin. Returns a list of event dicts.
+
+    Handles two formats:
+    - True NDJSON: one JSON object per line
+    - Pretty-printed concatenated JSON: as output by `ant` CLI (multi-line
+      objects separated by newlines)
+    """
+    if source == "-":
+        content = sys.stdin.read()
+    else:
+        path = Path(source)
+        if not path.exists():
+            print(f"Error: events file not found: {source}", file=sys.stderr)
+            sys.exit(EXIT_BAD_INPUT)
+        content = path.read_text(encoding="utf-8")
+
+    if not content.strip():
+        return []
+
+    # Try NDJSON first (one object per line)
+    lines = content.strip().splitlines()
+    first_line = lines[0].strip()
+    if first_line.startswith("{") and first_line.endswith("}"):
+        try:
+            events = [json.loads(line) for line in lines if line.strip()]
+            return events
+        except json.JSONDecodeError:
+            pass
+
+    # Fall back to incremental parsing for pretty-printed JSON
+    events = []
+    decoder = json.JSONDecoder()
+    pos = 0
+    while pos < len(content):
+        remaining = content[pos:].lstrip()
+        if not remaining:
+            break
+        pos = len(content) - len(remaining)
+        try:
+            obj, end = decoder.raw_decode(content, pos)
+            events.append(obj)
+            pos += end
+        except json.JSONDecodeError as exc:
+            print(
+                f"Warning: JSON parse error at position {pos}: {exc}",
+                file=sys.stderr,
+            )
+            break
+
+    return events
+
+
+def extract_text(events):
+    """Extract all text content from agent.message events.
+
+    Returns the concatenated text from all text content blocks across all
+    agent.message events, joined by newlines.
+    """
+    parts = []
+    for event in events:
+        if event.get("type") != "agent.message":
+            continue
+        for block in event.get("content", []):
+            if block.get("type") == "text":
+                parts.append(block["text"])
+    return "\n".join(parts) if parts else ""
+
+
+def compute_runtime(created_at, updated_at):
+    """Compute human-readable runtime from ISO timestamps."""
+    if not created_at or not updated_at:
+        return "unknown"
+    try:
+        start = datetime.fromisoformat(created_at.replace("Z", "+00:00"))
+        end = datetime.fromisoformat(updated_at.replace("Z", "+00:00"))
+        delta = end - start
+        total_seconds = int(delta.total_seconds())
+        if total_seconds < 0:
+            return "unknown"
+        minutes, seconds = divmod(total_seconds, 60)
+        if minutes > 0:
+            return f"{minutes}m{seconds:02d}s"
+        return f"{seconds}s"
+    except (ValueError, TypeError):
+        return "unknown"
+
+
+def slugify(text):
+    """Convert a topic label to a filename-safe slug."""
+    slug = text.lower().strip()
+    slug = re.sub(r"[^a-z0-9\s-]", "", slug)
+    slug = re.sub(r"[\s]+", "-", slug)
+    slug = re.sub(r"-+", "-", slug)
+    slug = slug.strip("-")
+    return slug
+
+
+def write_output_file(output_dir, index, session, text, extracted_at):
+    """Write a markdown output file with YAML frontmatter.
+
+    Returns the relative path to the output file.
+    """
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    slug = slugify(session["topic"])
+    filename = f"{index:02d}-{slug}.md"
+    filepath = output_dir / filename
+
+    runtime = compute_runtime(
+        session.get("created_at"), session.get("updated_at")
+    )
+
+    frontmatter = (
+        f"---\n"
+        f"session_id: {session['id']}\n"
+        f"session_url: {session.get('url', '')}\n"
+        f"topic: {session['topic']}\n"
+        f"status: {session.get('status', 'unknown')}\n"
+        f"runtime: {runtime}\n"
+        f"output_tokens: {session.get('output_tokens', 0)}\n"
+        f"extracted_at: {extracted_at}\n"
+        f"---\n\n"
+    )
+
+    filepath.write_text(frontmatter + text, encoding="utf-8")
+    return str(filepath)
+
+
+def update_run_file(run_file_path, updates):
+    """Atomically update the run file with extraction results.
+
+    `updates` is a dict mapping session ID to a dict with keys:
+    result, output_file, and optionally status.
+
+    Writes to a temp file in the same directory, then renames (atomic on
+    POSIX).
+    """
+    run_path = Path(run_file_path)
+    if not run_path.exists():
+        print(f"Error: run file not found: {run_file_path}", file=sys.stderr)
+        sys.exit(EXIT_BAD_INPUT)
+
+    run_data = json.loads(run_path.read_text(encoding="utf-8"))
+
+    for session in run_data.get("sessions", []):
+        sid = session["id"]
+        if sid in updates:
+            session.update(updates[sid])
+
+    run_data["gathered_at"] = datetime.now(timezone.utc).strftime(
+        "%Y-%m-%dT%H:%M:%SZ"
+    )
+
+    # Atomic write: temp file + rename
+    fd, tmp_path = tempfile.mkstemp(
+        dir=run_path.parent, suffix=".tmp", prefix=".run-"
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(run_data, f, indent=2, ensure_ascii=False)
+            f.write("\n")
+        os.replace(tmp_path, run_path)
+    except Exception:
+        # Clean up temp file on failure
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+    return run_data
+
+
+def cmd_extract(args):
+    """Extract text from an NDJSON events file (or stdin)."""
+    source = args.events_file or "-"
+    events = parse_ndjson(source)
+
+    if not events:
+        print("Error: no events found in input.", file=sys.stderr)
+        sys.exit(EXIT_NO_EVENTS)
+
+    text = extract_text(events)
+    byte_count = len(text.encode("utf-8"))
+
+    result = {
+        "text": text,
+        "byte_count": byte_count,
+        "event_count": len(events),
+        "agent_message_count": sum(
+            1 for e in events if e.get("type") == "agent.message"
+        ),
+        "flagged": byte_count < MIN_BYTES_THRESHOLD,
+    }
+
+    if result["flagged"]:
+        print(
+            f"Warning: extracted text is only {byte_count} bytes "
+            f"(threshold: {MIN_BYTES_THRESHOLD}). "
+            f"Agent likely wrote to files instead of messages.",
+            file=sys.stderr,
+        )
+
+    if args.output == "json":
+        json.dump(result, sys.stdout, ensure_ascii=False)
+        sys.stdout.write("\n")
+    else:
+        sys.stdout.write(text)
+
+    return EXIT_PARTIAL if result["flagged"] else EXIT_OK
+
+
+def cmd_gather(args):
+    """Gather results for all sessions in a run file.
+
+    For each session, reads NDJSON from the events directory (or calls
+    `ant` CLI if --live is set), extracts text, writes output files, and
+    updates the run file atomically.
+    """
+    run_path = Path(args.run_file)
+    if not run_path.exists():
+        print(f"Error: run file not found: {args.run_file}", file=sys.stderr)
+        sys.exit(EXIT_BAD_INPUT)
+
+    run_data = json.loads(run_path.read_text(encoding="utf-8"))
+    run_id = run_data["id"]
+    sessions = run_data.get("sessions", [])
+
+    # Output directory: sibling to run file, named after run ID
+    output_dir = run_path.parent / run_id
+
+    events_dir = Path(args.events_dir) if args.events_dir else None
+
+    extracted_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    updates = {}
+    results = []
+    has_flagged = False
+
+    for i, session in enumerate(sessions, start=1):
+        sid = session["id"]
+        status = session.get("status", "")
+
+        if status == "terminated":
+            results.append({
+                "index": i,
+                "session_id": sid,
+                "topic": session["topic"],
+                "status": "terminated",
+                "byte_count": 0,
+                "flagged": False,
+                "output_file": None,
+            })
+            continue
+
+        # Find events for this session
+        events = []
+        if events_dir:
+            # Look for a file named after the session ID
+            events_file = events_dir / f"{sid}.ndjson"
+            if events_file.exists():
+                events = parse_ndjson(str(events_file))
+            else:
+                print(
+                    f"Warning: no events file for session {sid} "
+                    f"at {events_file}",
+                    file=sys.stderr,
+                )
+        elif args.live:
+            # Call ant CLI to fetch events
+            import subprocess
+
+            try:
+                proc = subprocess.run(
+                    [
+                        "ant", "beta:sessions:events", "list",
+                        "--session-id", sid,
+                        "--type", "agent.message",
+                        "--max-items", "-1",
+                    ],
+                    capture_output=True,
+                    text=True,
+                    timeout=120,
+                )
+                if proc.returncode == 0 and proc.stdout.strip():
+                    events = parse_ndjson_string(proc.stdout)
+                else:
+                    print(
+                        f"Warning: ant CLI returned no data for {sid}",
+                        file=sys.stderr,
+                    )
+            except (subprocess.TimeoutExpired, FileNotFoundError) as exc:
+                print(
+                    f"Warning: ant CLI failed for {sid}: {exc}",
+                    file=sys.stderr,
+                )
+        else:
+            print(
+                f"Error: no events source specified. "
+                f"Use --events-dir or --live.",
+                file=sys.stderr,
+            )
+            sys.exit(EXIT_BAD_INPUT)
+
+        text = extract_text(events)
+        byte_count = len(text.encode("utf-8"))
+        flagged = byte_count < MIN_BYTES_THRESHOLD
+
+        if flagged:
+            has_flagged = True
+            print(
+                f"Warning: session {sid} ({session['topic']}): "
+                f"only {byte_count} bytes extracted. "
+                f"Agent likely wrote to files.",
+                file=sys.stderr,
+            )
+
+        # Write output file if we have text
+        output_file = None
+        if text:
+            output_file = write_output_file(
+                output_dir, i, session, text, extracted_at
+            )
+
+        updates[sid] = {
+            "result": text if text else None,
+            "output_file": output_file,
+        }
+
+        results.append({
+            "index": i,
+            "session_id": sid,
+            "topic": session["topic"],
+            "status": status,
+            "byte_count": byte_count,
+            "flagged": flagged,
+            "output_file": output_file,
+        })
+
+    # Update run file atomically
+    if not args.dry_run:
+        update_run_file(args.run_file, updates)
+        print(f"Updated run file: {args.run_file}", file=sys.stderr)
+    else:
+        print("Dry run: run file not updated.", file=sys.stderr)
+
+    # Output results
+    output = {
+        "run_id": run_id,
+        "sessions": results,
+        "total": len(sessions),
+        "extracted": sum(1 for r in results if r["byte_count"] > 0),
+        "flagged": sum(1 for r in results if r["flagged"]),
+        "terminated": sum(
+            1 for r in results if r["status"] == "terminated"
+        ),
+        "output_dir": str(output_dir),
+    }
+
+    json.dump(output, sys.stdout, indent=2, ensure_ascii=False)
+    sys.stdout.write("\n")
+
+    return EXIT_PARTIAL if has_flagged else EXIT_OK
+
+
+def parse_ndjson_string(content):
+    """Parse NDJSON from a string (used for subprocess output)."""
+    if not content.strip():
+        return []
+    lines = content.strip().splitlines()
+    first_line = lines[0].strip()
+    if first_line.startswith("{") and first_line.endswith("}"):
+        try:
+            return [json.loads(line) for line in lines if line.strip()]
+        except json.JSONDecodeError:
+            pass
+    events = []
+    decoder = json.JSONDecoder()
+    pos = 0
+    while pos < len(content):
+        remaining = content[pos:].lstrip()
+        if not remaining:
+            break
+        pos = len(content) - len(remaining)
+        try:
+            obj, end = decoder.raw_decode(content, pos)
+            events.append(obj)
+            pos += end
+        except json.JSONDecodeError:
+            break
+    return events
+
+
+def build_parser():
+    parser = argparse.ArgumentParser(
+        prog="dispatch_gather",
+        description="Extract results from dispatch managed agent sessions.",
+        epilog=(
+            "Exit codes:\n"
+            "  0  All sessions extracted successfully\n"
+            "  1  Some sessions had low byte counts (< 500 bytes)\n"
+            "  2  Invalid input (missing file, bad JSON)\n"
+            "  3  No events found\n"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    # extract: single-session extraction
+    p_extract = sub.add_parser(
+        "extract",
+        help="Extract text from a single session's NDJSON events.",
+    )
+    p_extract.add_argument(
+        "events_file",
+        nargs="?",
+        help="Path to NDJSON events file. Reads stdin if omitted.",
+    )
+    p_extract.add_argument(
+        "--output",
+        choices=["json", "text"],
+        default="json",
+        help="Output format (default: json).",
+    )
+    p_extract.set_defaults(func=cmd_extract)
+
+    # gather: multi-session extraction from a run file
+    p_gather = sub.add_parser(
+        "gather",
+        help="Gather results for all sessions in a run file.",
+    )
+    p_gather.add_argument(
+        "run_file",
+        help="Path to the dispatch run file (.json).",
+    )
+    p_gather.add_argument(
+        "--events-dir",
+        help=(
+            "Directory containing per-session NDJSON files "
+            "(named {session_id}.ndjson)."
+        ),
+    )
+    p_gather.add_argument(
+        "--live",
+        action="store_true",
+        help="Fetch events from ant CLI instead of local files.",
+    )
+    p_gather.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Extract and report without updating the run file.",
+    )
+    p_gather.set_defaults(func=cmd_gather)
+
+    return parser
+
+
+def main():
+    parser = build_parser()
+    args = parser.parse_args()
+    exit_code = args.func(args)
+    sys.exit(exit_code)
+
+
+if __name__ == "__main__":
+    main()

--- a/claude/skills/dispatch/tests/conftest.py
+++ b/claude/skills/dispatch/tests/conftest.py
@@ -1,0 +1,53 @@
+"""Shared fixtures for dispatch gather tests."""
+
+from pathlib import Path
+
+import pytest
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+
+
+@pytest.fixture
+def fixtures_dir():
+    return FIXTURES_DIR
+
+
+@pytest.fixture
+def complete_events_path(fixtures_dir):
+    return fixtures_dir / "session-complete.ndjson"
+
+
+@pytest.fixture
+def empty_events_path(fixtures_dir):
+    return fixtures_dir / "session-empty.ndjson"
+
+
+@pytest.fixture
+def run_file_path(fixtures_dir):
+    return fixtures_dir / "run-file.json"
+
+
+@pytest.fixture
+def tmp_run_file(tmp_path, run_file_path):
+    """Copy the run file fixture to a temp dir so tests can mutate it."""
+    import shutil
+
+    dest = tmp_path / "run-file.json"
+    shutil.copy2(run_file_path, dest)
+    return dest
+
+
+@pytest.fixture
+def tmp_events_dir(tmp_path, complete_events_path, empty_events_path):
+    """Set up a temp events directory with per-session NDJSON files."""
+    import shutil
+
+    events_dir = tmp_path / "events"
+    events_dir.mkdir()
+    shutil.copy2(
+        complete_events_path, events_dir / "sesn_01COMPLETE.ndjson"
+    )
+    shutil.copy2(
+        empty_events_path, events_dir / "sesn_01EMPTY.ndjson"
+    )
+    return events_dir

--- a/claude/skills/dispatch/tests/fixtures/run-file.json
+++ b/claude/skills/dispatch/tests/fixtures/run-file.json
@@ -1,0 +1,43 @@
+{
+  "id": "20260708-test-run",
+  "created_at": "2026-07-08T12:32:57Z",
+  "agent_id": "agent_01TEST",
+  "environment_id": "env_01TEST",
+  "workspace_id": "wrkspc_01TEST",
+  "context": "Test dispatch run",
+  "sessions": [
+    {
+      "id": "sesn_01COMPLETE",
+      "topic": "Enterprise search landscape",
+      "url": "https://console.anthropic.com/workspaces/wrkspc_01TEST/sessions/sesn_01COMPLETE",
+      "status": "idle",
+      "created_at": "2026-07-08T12:32:57.000000Z",
+      "updated_at": "2026-07-08T12:35:33.000000Z",
+      "output_tokens": 3803,
+      "result": null,
+      "output_file": null
+    },
+    {
+      "id": "sesn_01EMPTY",
+      "topic": "Graph databases",
+      "url": "https://console.anthropic.com/workspaces/wrkspc_01TEST/sessions/sesn_01EMPTY",
+      "status": "idle",
+      "created_at": "2026-07-08T12:32:57.000000Z",
+      "updated_at": "2026-07-08T12:35:33.000000Z",
+      "output_tokens": 150,
+      "result": null,
+      "output_file": null
+    },
+    {
+      "id": "sesn_01TERMINATED",
+      "topic": "Auth patterns",
+      "url": "https://console.anthropic.com/workspaces/wrkspc_01TEST/sessions/sesn_01TERMINATED",
+      "status": "terminated",
+      "created_at": "2026-07-08T12:32:57.000000Z",
+      "updated_at": "2026-07-08T12:33:02.000000Z",
+      "output_tokens": 0,
+      "result": null,
+      "output_file": null
+    }
+  ]
+}

--- a/claude/skills/dispatch/tests/fixtures/session-complete.ndjson
+++ b/claude/skills/dispatch/tests/fixtures/session-complete.ndjson
@@ -1,0 +1,13 @@
+{"id":"sevt_01aaa","processed_at":"2026-07-08T12:32:57.893874Z","type":"session.status_running"}
+{"agent_name":"Coding Assistant","id":"sevt_01bbb","processed_at":"2026-07-08T12:32:57.893875Z","session_thread_id":"sthr_01xxx","type":"session.thread_status_running"}
+{"content":[{"text":"Research the enterprise search landscape.","type":"text"}],"id":"sevt_01ccc","processed_at":"2026-07-08T12:32:58.059505Z","type":"user.message"}
+{"id":"sevt_01ddd","processed_at":"2026-07-08T12:32:58.059506Z","type":"span.model_request_start"}
+{"id":"sevt_01eee","processed_at":"2026-07-08T12:33:00.972230Z","type":"agent.thinking"}
+{"evaluated_permission":"allow","id":"sevt_01fff","input":{"query":"enterprise search landscape 2026"},"name":"web_search","processed_at":"2026-07-08T12:33:01.123456Z","type":"agent.tool_use"}
+{"id":"sevt_01ggg","processed_at":"2026-07-08T12:33:05.234567Z","type":"agent.tool_result","content":[{"text":"Search results...","type":"text"}]}
+{"content":[{"text":"I'll compile the findings now.","type":"text"}],"id":"sevt_01hhh","processed_at":"2026-07-08T12:34:05.040979Z","type":"agent.message"}
+{"id":"sevt_01iii","processed_at":"2026-07-08T12:34:06.000000Z","type":"span.model_request_end"}
+{"id":"sevt_01jjj","processed_at":"2026-07-08T12:34:06.100000Z","type":"span.model_request_start"}
+{"content":[{"text":"# Enterprise Search Landscape 2026\n\n## Key Players\n\n| Vendor | Type | Pricing |\n|---|---|---|\n| Elasticsearch | Open source | Free / Cloud from $95/mo |\n| Algolia | SaaS | From $1/1K requests |\n| Typesense | Open source | Free / Cloud from $29/mo |\n| Meilisearch | Open source | Free / Cloud from $30/mo |\n\n## Analysis\n\nThe enterprise search market continues to evolve with AI-native approaches.\nVector search capabilities are now table stakes.\n","type":"text"},{"text":"## Recommendations\n\nFor ivos-trades, Typesense offers the best balance of cost and capability.\nElasticsearch remains the safe enterprise choice.\n","type":"text"}],"id":"sevt_01kkk","processed_at":"2026-07-08T12:35:30.654300Z","type":"agent.message"}
+{"agent_name":"Coding Assistant","id":"sevt_01lll","processed_at":"2026-07-08T12:35:33.654379Z","session_thread_id":"sthr_01xxx","stop_reason":{"type":"end_turn"},"type":"session.thread_status_idle"}
+{"id":"sevt_01mmm","processed_at":"2026-07-08T12:35:33.654380Z","stop_reason":{"type":"end_turn"},"type":"session.status_idle"}

--- a/claude/skills/dispatch/tests/fixtures/session-empty.ndjson
+++ b/claude/skills/dispatch/tests/fixtures/session-empty.ndjson
@@ -1,0 +1,11 @@
+{"id":"sevt_01aaa","processed_at":"2026-07-08T12:32:57.893874Z","type":"session.status_running"}
+{"agent_name":"Coding Assistant","id":"sevt_01bbb","processed_at":"2026-07-08T12:32:57.893875Z","session_thread_id":"sthr_01xxx","type":"session.thread_status_running"}
+{"content":[{"text":"Research the graph database landscape.","type":"text"}],"id":"sevt_01ccc","processed_at":"2026-07-08T12:32:58.059505Z","type":"user.message"}
+{"id":"sevt_01ddd","processed_at":"2026-07-08T12:32:58.059506Z","type":"span.model_request_start"}
+{"id":"sevt_01eee","processed_at":"2026-07-08T12:33:00.972230Z","type":"agent.thinking"}
+{"evaluated_permission":"allow","id":"sevt_01fff","input":{"query":"graph database comparison"},"name":"web_search","processed_at":"2026-07-08T12:33:01.123456Z","type":"agent.tool_use"}
+{"id":"sevt_01ggg","processed_at":"2026-07-08T12:33:05.234567Z","type":"agent.tool_result","content":[{"text":"Search results...","type":"text"}]}
+{"content":[{"text":"Done.","type":"text"}],"id":"sevt_01hhh","processed_at":"2026-07-08T12:34:05.040979Z","type":"agent.message"}
+{"id":"sevt_01iii","processed_at":"2026-07-08T12:34:06.000000Z","type":"span.model_request_end"}
+{"agent_name":"Coding Assistant","id":"sevt_01lll","processed_at":"2026-07-08T12:35:33.654379Z","session_thread_id":"sthr_01xxx","stop_reason":{"type":"end_turn"},"type":"session.thread_status_idle"}
+{"id":"sevt_01mmm","processed_at":"2026-07-08T12:35:33.654380Z","stop_reason":{"type":"end_turn"},"type":"session.status_idle"}

--- a/claude/skills/dispatch/tests/test_dispatch_gather.py
+++ b/claude/skills/dispatch/tests/test_dispatch_gather.py
@@ -1,0 +1,312 @@
+"""Tests for dispatch_gather.py."""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+# Add scripts dir to path so we can import the module
+SCRIPTS_DIR = Path(__file__).parent.parent / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+import dispatch_gather as dg
+
+
+class TestParseNdjson:
+    def test_parses_ndjson_file(self, complete_events_path):
+        events = dg.parse_ndjson(str(complete_events_path))
+        assert len(events) == 13
+        types = {e["type"] for e in events}
+        assert "agent.message" in types
+        assert "user.message" in types
+        assert "session.status_running" in types
+
+    def test_parses_empty_file(self, tmp_path):
+        empty = tmp_path / "empty.ndjson"
+        empty.write_text("")
+        events = dg.parse_ndjson(str(empty))
+        assert events == []
+
+    def test_exits_on_missing_file(self):
+        with pytest.raises(SystemExit) as exc_info:
+            dg.parse_ndjson("/nonexistent/file.ndjson")
+        assert exc_info.value.code == dg.EXIT_BAD_INPUT
+
+
+class TestExtractText:
+    def test_extracts_agent_message_text(self, complete_events_path):
+        events = dg.parse_ndjson(str(complete_events_path))
+        text = dg.extract_text(events)
+        assert "Enterprise Search Landscape 2026" in text
+        assert "Typesense" in text
+        assert "I'll compile the findings now." in text
+
+    def test_ignores_non_agent_message_events(self, complete_events_path):
+        events = dg.parse_ndjson(str(complete_events_path))
+        text = dg.extract_text(events)
+        # user.message content should not appear
+        assert "Research the enterprise search landscape" not in text
+
+    def test_empty_on_no_agent_messages(self):
+        events = [
+            {"type": "session.status_running", "id": "x"},
+            {"type": "user.message", "id": "y", "content": [
+                {"type": "text", "text": "hello"}
+            ]},
+        ]
+        text = dg.extract_text(events)
+        assert text == ""
+
+    def test_joins_multiple_text_blocks(self):
+        events = [
+            {"type": "agent.message", "id": "a", "content": [
+                {"type": "text", "text": "Part 1."},
+                {"type": "text", "text": "Part 2."},
+            ]},
+        ]
+        text = dg.extract_text(events)
+        assert "Part 1." in text
+        assert "Part 2." in text
+
+    def test_low_byte_count_flagged(self, empty_events_path):
+        events = dg.parse_ndjson(str(empty_events_path))
+        text = dg.extract_text(events)
+        byte_count = len(text.encode("utf-8"))
+        assert byte_count < dg.MIN_BYTES_THRESHOLD
+        assert text == "Done."
+
+
+class TestComputeRuntime:
+    def test_computes_minutes_and_seconds(self):
+        result = dg.compute_runtime(
+            "2026-07-08T12:32:57.000000Z",
+            "2026-07-08T12:35:33.000000Z",
+        )
+        assert result == "2m36s"
+
+    def test_computes_seconds_only(self):
+        result = dg.compute_runtime(
+            "2026-07-08T12:32:57.000000Z",
+            "2026-07-08T12:33:02.000000Z",
+        )
+        assert result == "5s"
+
+    def test_handles_none(self):
+        assert dg.compute_runtime(None, None) == "unknown"
+        assert dg.compute_runtime("2026-07-08T12:32:57Z", None) == "unknown"
+
+
+class TestSlugify:
+    def test_basic_slugify(self):
+        assert dg.slugify("Enterprise search landscape") == "enterprise-search-landscape"
+
+    def test_strips_special_chars(self):
+        assert dg.slugify("Dark-pool / options-flow") == "dark-pool-options-flow"
+
+    def test_handles_unicode(self):
+        slug = dg.slugify("Politician/Congressional trades")
+        assert "/" not in slug
+
+
+class TestWriteOutputFile:
+    def test_writes_frontmatter_and_content(self, tmp_path):
+        session = {
+            "id": "sesn_01TEST",
+            "topic": "Test topic",
+            "url": "https://example.com/session",
+            "status": "idle",
+            "created_at": "2026-07-08T12:32:57.000000Z",
+            "updated_at": "2026-07-08T12:35:33.000000Z",
+            "output_tokens": 1234,
+        }
+        text = "# Test Output\n\nSome content here."
+        path = dg.write_output_file(
+            tmp_path / "output", 1, session, text, "2026-07-08T13:00:00Z"
+        )
+
+        content = Path(path).read_text()
+        assert "---" in content
+        assert "session_id: sesn_01TEST" in content
+        assert "topic: Test topic" in content
+        assert "runtime: 2m36s" in content
+        assert "output_tokens: 1234" in content
+        assert "# Test Output" in content
+
+    def test_filename_format(self, tmp_path):
+        session = {
+            "id": "sesn_01TEST",
+            "topic": "Enterprise search landscape",
+            "url": "",
+            "status": "idle",
+            "output_tokens": 0,
+        }
+        path = dg.write_output_file(
+            tmp_path / "output", 3, session, "text", "2026-07-08T13:00:00Z"
+        )
+        assert Path(path).name == "03-enterprise-search-landscape.md"
+
+    def test_creates_output_dir(self, tmp_path):
+        output_dir = tmp_path / "nested" / "output"
+        session = {
+            "id": "sesn_01TEST",
+            "topic": "Test",
+            "url": "",
+            "status": "idle",
+            "output_tokens": 0,
+        }
+        dg.write_output_file(output_dir, 1, session, "text", "now")
+        assert output_dir.exists()
+
+
+class TestUpdateRunFile:
+    def test_updates_sessions_atomically(self, tmp_run_file):
+        updates = {
+            "sesn_01COMPLETE": {
+                "result": "extracted text here",
+                "output_file": "output/01-enterprise-search.md",
+            },
+        }
+        run_data = dg.update_run_file(str(tmp_run_file), updates)
+
+        # Verify the file was updated
+        saved = json.loads(tmp_run_file.read_text())
+        session = next(
+            s for s in saved["sessions"] if s["id"] == "sesn_01COMPLETE"
+        )
+        assert session["result"] == "extracted text here"
+        assert session["output_file"] == "output/01-enterprise-search.md"
+        assert "gathered_at" in saved
+
+    def test_preserves_unmodified_sessions(self, tmp_run_file):
+        updates = {"sesn_01COMPLETE": {"result": "text"}}
+        dg.update_run_file(str(tmp_run_file), updates)
+
+        saved = json.loads(tmp_run_file.read_text())
+        terminated = next(
+            s for s in saved["sessions"] if s["id"] == "sesn_01TERMINATED"
+        )
+        assert terminated["status"] == "terminated"
+        assert terminated["result"] is None
+
+    def test_exits_on_missing_run_file(self):
+        with pytest.raises(SystemExit) as exc_info:
+            dg.update_run_file("/nonexistent/run.json", {})
+        assert exc_info.value.code == dg.EXIT_BAD_INPUT
+
+
+class TestCLIExtract:
+    def test_extract_json_output(self, complete_events_path):
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPTS_DIR / "dispatch_gather.py"),
+                "extract",
+                str(complete_events_path),
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0
+        data = json.loads(result.stdout)
+        assert data["byte_count"] > dg.MIN_BYTES_THRESHOLD
+        assert data["flagged"] is False
+        assert data["agent_message_count"] == 2
+
+    def test_extract_text_output(self, complete_events_path):
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPTS_DIR / "dispatch_gather.py"),
+                "extract",
+                "--output", "text",
+                str(complete_events_path),
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0
+        assert "Enterprise Search Landscape" in result.stdout
+        # JSON should not be in text output
+        assert '"byte_count"' not in result.stdout
+
+    def test_extract_flagged_exit_code(self, empty_events_path):
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPTS_DIR / "dispatch_gather.py"),
+                "extract",
+                str(empty_events_path),
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == dg.EXIT_PARTIAL
+        data = json.loads(result.stdout)
+        assert data["flagged"] is True
+        assert "wrote to files" in result.stderr
+
+
+class TestCLIGather:
+    def test_gather_dry_run(
+        self, tmp_run_file, tmp_events_dir
+    ):
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPTS_DIR / "dispatch_gather.py"),
+                "gather",
+                str(tmp_run_file),
+                "--events-dir", str(tmp_events_dir),
+                "--dry-run",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        # Exit 1 because one session is flagged
+        assert result.returncode == dg.EXIT_PARTIAL
+        data = json.loads(result.stdout)
+        assert data["total"] == 3
+        assert data["extracted"] == 2
+        assert data["flagged"] == 1
+        assert data["terminated"] == 1
+
+        # Dry run should not modify the run file
+        original = json.loads(
+            (Path(__file__).parent / "fixtures" / "run-file.json").read_text()
+        )
+        current = json.loads(tmp_run_file.read_text())
+        assert current == original
+
+    def test_gather_updates_run_file(
+        self, tmp_run_file, tmp_events_dir
+    ):
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPTS_DIR / "dispatch_gather.py"),
+                "gather",
+                str(tmp_run_file),
+                "--events-dir", str(tmp_events_dir),
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == dg.EXIT_PARTIAL
+
+        saved = json.loads(tmp_run_file.read_text())
+        assert "gathered_at" in saved
+
+        complete = next(
+            s for s in saved["sessions"] if s["id"] == "sesn_01COMPLETE"
+        )
+        assert complete["result"] is not None
+        assert "Enterprise Search" in complete["result"]
+        assert complete["output_file"] is not None
+
+        terminated = next(
+            s for s in saved["sessions"] if s["id"] == "sesn_01TERMINATED"
+        )
+        assert terminated["result"] is None
+        assert terminated["output_file"] is None

--- a/claude/skills/dispatch/uv.lock
+++ b/claude/skills/dispatch/uv.lock
@@ -1,0 +1,79 @@
+version = 1
+revision = 3
+requires-python = ">=3.11"
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "dispatch-skill"
+version = "0.1.0"
+source = { virtual = "." }
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
+[package.metadata]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = ">=8.0" }]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]

--- a/flake.nix
+++ b/flake.nix
@@ -83,7 +83,7 @@
       {
         checks.pre-commit-check = pre-commit-check;
         devShells.default = pkgs.mkShell {
-          packages = [ pkgs.emacs pkgs.gitleaks pkgs.cargo pkgs.rustc ];
+          packages = [ pkgs.emacs pkgs.gitleaks pkgs.cargo pkgs.rustc pkgs.python3 pkgs.uv ];
           inherit (pre-commit-check) shellHook;
           buildInputs = pre-commit-check.enabledPackages;
         };


### PR DESCRIPTION
## Summary
- Add `dispatch_gather.py` — Python script for extracting results from managed agent sessions (NDJSON parsing, agent.message text extraction, byte-count validation, YAML frontmatter output files, atomic run file updates)
- Add per-skill `pyproject.toml` with pytest dev dependency, enabling `uv sync && uv run pytest` workflow
- Add `python3` and `uv` to flake.nix devShell
- 25 pytest tests against fixture data, all passing

## Test plan
- [x] `uv run pytest tests/` — 25/25 passing (0.18s)
- [ ] Run `dispatch_gather.py extract` against a real session's NDJSON output
- [ ] Run `dispatch_gather.py gather` against a real run file with `--live` flag

Closes VID-698

🤖 Generated with [Claude Code](https://claude.com/claude-code)