### PR TITLE
feat(skills): make dispatch session-creation drop-proof [VID-705]

### DIFF
--- a/claude/skills/dispatch/.gitignore
+++ b/claude/skills/dispatch/.gitignore
@@ -1,2 +1,3 @@
 .venv/
 .pytest_cache/
+__pycache__/

--- a/claude/skills/dispatch/DISPATCH.md
+++ b/claude/skills/dispatch/DISPATCH.md
@@ -36,6 +36,14 @@ done
 echo "]"
 ```
 
+**Resolved (VID-705):** shipped as `scripts/dispatch_create.py` — but in Python,
+not shell. The `create` command owns the loop, pairs each session with its topic
+via `assemble_sessions` (an explicit length guard that errors rather than
+silently dropping), and writes the run file directly. It also folds in a
+credential preflight (the first create fails fast on a bad credential). Covered
+by `tests/test_dispatch_create.py`, including a 10-session regression guard for
+this exact drop. `SKILL.md` Phase 1 now calls it instead of an inline shell loop.
+
 ### Error 2: workspace_id not discoverable from `ant` CLI
 
 **What happened:** `ant beta:sessions create` output does not include

--- a/claude/skills/dispatch/SKILL.md
+++ b/claude/skills/dispatch/SKILL.md
@@ -172,31 +172,39 @@ the caller's prompt text. Never dispatch a prompt without it.
 
 ### Create sessions and send prompts
 
-For each confirmed topic:
+**Create all sessions with the script — never hand-roll the create loop in
+shell.** `scripts/dispatch_create.py` owns session creation: it runs a
+credential preflight, pairs each session with its topic in Python (no shell-array
+indexing — the bug behind DISPATCH.md Error 1), builds each session's console
+URL, and writes the run file.
 
-1. **Create session:**
+1. **Create sessions + run file:** write the topic labels to a file (one per
+   line, in the same order as your prompts), then:
    ```bash
-   ant beta:sessions create \
+   python3 scripts/dispatch_create.py create topics.txt \
      --agent "$AGENT_ID" \
-     --environment-id "$ENV_ID"
+     --environment-id "$ENV_ID" \
+     --workspace-id "$WORKSPACE_ID" \
+     --context "$CONTEXT"
    ```
-   Parse the session ID from the JSON output.
+   The **first create is a credential preflight** — if the credential is
+   expired the script exits fast (exit 1) pointing at `ant auth login`, before
+   the rest of the batch is attempted. On success the run file is written to
+   `.dispatch-runs/{run-id}.json` with every session's ID, topic, and console
+   URL already populated.
 
-2. **Send prompt:**
-   Assemble the final prompt by prepending the output-capture envelope (above)
-   to the caller's prompt, write the result to a temp file to avoid shell
-   escaping issues, then:
+2. **Send each prompt:** for each session in the run file, assemble the final
+   prompt by prepending the output-capture envelope (above) to the caller's
+   prompt, write it to a temp file to avoid shell escaping issues, then:
    ```bash
    ant beta:sessions:events send \
      --session-id "$SID" \
      --event "{\"type\": \"user.message\", \"content\": [{\"type\": \"text\", \"text\": $(jq -Rs . < /tmp/prompt-N.txt)}]}"
    ```
+   Send prompts in parallel where possible (background with `&`).
 
-3. **Build session URL:** Construct `https://console.anthropic.com/workspaces/{workspace_id}/sessions/{session_id}` and store it in the session's `url` field. This happens at creation time so the URL is persisted from the start — not deferred to gather.
-
-4. **Record** the session ID, URL, and topic in the run file.
-
-Dispatch sessions in parallel where possible (background with `&`). But always write the run file to disk **before** reporting success — if the session dies mid-dispatch, the persisted IDs let us recover.
+The create script writes the run file to disk **before** any prompt is sent — if
+a send dies mid-dispatch, the persisted IDs let us recover.
 
 ### Report
 

--- a/claude/skills/dispatch/scripts/dispatch_create.py
+++ b/claude/skills/dispatch/scripts/dispatch_create.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Create dispatch managed agent sessions and build the run file.
+
+Owns the fragile parts of session creation that shell arrays got wrong: pairing
+created session IDs with their topics by index, and assembling a clean run-file
+JSON. zsh arrays are 1-indexed, so a `for i in $(seq 0 …)` loop over a
+`+=`-built array silently blanked the first entry and dropped the last (see
+DISPATCH.md Error 1). This script owns the loop in Python, guaranteeing a
+one-to-one, order-preserving mapping with an explicit length guard.
+
+The assembly functions here are pure and CLI-free so they can be unit-tested
+without the `ant` CLI. The subprocess wrapper and the `create` command (with the
+credential preflight) build on top of them.
+
+Designed for agentic use: structured JSON on stdout, diagnostics on stderr,
+meaningful exit codes.
+"""
+
+# Exit codes
+EXIT_OK = 0
+EXIT_BAD_CREDENTIAL = 1  # preflight create failed — credential likely expired
+EXIT_BAD_INPUT = 2       # invalid input (length mismatch, missing config)
+
+CONSOLE_URL_BASE = "https://console.anthropic.com"
+
+
+def build_session_url(workspace_id, session_id):
+    """Construct the console URL for a session.
+
+    Mirrors the URL the gather phase reads from the run file's `url` field, so
+    every output surface points at the same place.
+    """
+    return (
+        f"{CONSOLE_URL_BASE}/workspaces/{workspace_id}/sessions/{session_id}"
+    )
+
+
+def build_session(topic, session_id, index, workspace_id):
+    """Build a single run-file session entry.
+
+    The schema matches what the gather phase expects to read and update:
+    creation-time fields are populated; the rest are null placeholders filled in
+    later. `index` is 1-based (the display position), kept for callers that want
+    it but not stored — the position is implied by list order.
+    """
+    return {
+        "id": session_id,
+        "topic": topic,
+        "url": build_session_url(workspace_id, session_id),
+        "status": None,
+        "created_at": None,
+        "updated_at": None,
+        "output_tokens": None,
+        "result": None,
+        "output_file": None,
+    }
+
+
+def assemble_sessions(created_ids, topics, workspace_id):
+    """Pair created session IDs with their topics, in order.
+
+    This is the drop-proof core: `created_ids[i]` corresponds to `topics[i]`
+    for every i, with no off-by-one and no silent truncation. A length mismatch
+    is a hard error rather than a silently blanked or dropped entry — the exact
+    failure mode DISPATCH.md Error 1 documents.
+    """
+    if len(created_ids) != len(topics):
+        raise ValueError(
+            f"session/topic count mismatch: {len(created_ids)} sessions "
+            f"but {len(topics)} topics — refusing to build a run file with "
+            f"blank or dropped entries"
+        )
+    return [
+        build_session(topic, session_id, index, workspace_id)
+        for index, (session_id, topic) in enumerate(
+            zip(created_ids, topics), start=1
+        )
+    ]
+
+
+def build_run_file(
+    run_id,
+    agent_id,
+    environment_id,
+    workspace_id,
+    context,
+    sessions,
+    created_at,
+):
+    """Assemble the top-level run-file dict.
+
+    `created_at` and `run_id` are passed in (not stamped here) so the function
+    stays pure and deterministic for tests; the `create` command generates them
+    from the wall clock.
+    """
+    return {
+        "id": run_id,
+        "created_at": created_at,
+        "agent_id": agent_id,
+        "environment_id": environment_id,
+        "workspace_id": workspace_id,
+        "context": context,
+        "sessions": sessions,
+    }

--- a/claude/skills/dispatch/scripts/dispatch_create.py
+++ b/claude/skills/dispatch/scripts/dispatch_create.py
@@ -16,12 +16,29 @@ Designed for agentic use: structured JSON on stdout, diagnostics on stderr,
 meaningful exit codes.
 """
 
+import argparse
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
 # Exit codes
 EXIT_OK = 0
 EXIT_BAD_CREDENTIAL = 1  # preflight create failed — credential likely expired
 EXIT_BAD_INPUT = 2       # invalid input (length mismatch, missing config)
 
 CONSOLE_URL_BASE = "https://console.anthropic.com"
+
+CREATE_TIMEOUT_SECONDS = 60
+
+
+class SessionCreateError(Exception):
+    """A single `ant beta:sessions create` call failed."""
+
+
+class CredentialError(Exception):
+    """The preflight (first) create failed — the credential is likely bad."""
 
 
 def build_session_url(workspace_id, session_id):
@@ -102,3 +119,187 @@ def build_run_file(
         "context": context,
         "sessions": sessions,
     }
+
+
+def create_one_session(agent_id, environment_id):
+    """Create a single session via the `ant` CLI and return its ID.
+
+    Raises SessionCreateError if the CLI fails, times out, is missing, or emits
+    output we can't parse an `id` out of.
+    """
+    try:
+        proc = subprocess.run(
+            [
+                "ant", "beta:sessions", "create",
+                "--agent", agent_id,
+                "--environment-id", environment_id,
+            ],
+            capture_output=True,
+            text=True,
+            timeout=CREATE_TIMEOUT_SECONDS,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError) as exc:
+        raise SessionCreateError(f"ant create failed: {exc}") from exc
+
+    if proc.returncode != 0:
+        raise SessionCreateError(
+            f"ant create exited {proc.returncode}: "
+            f"{proc.stderr.strip() or proc.stdout.strip()}"
+        )
+
+    try:
+        session_id = json.loads(proc.stdout).get("id")
+    except json.JSONDecodeError as exc:
+        raise SessionCreateError(
+            f"could not parse ant create output as JSON: {exc}"
+        ) from exc
+
+    if not session_id:
+        raise SessionCreateError("ant create output had no `id` field")
+
+    return session_id
+
+
+def create_sessions(
+    topics,
+    agent_id,
+    environment_id,
+    workspace_id,
+    creator=create_one_session,
+):
+    """Create one session per topic and assemble the run-file session list.
+
+    The **first** create doubles as a credential preflight: if it fails, we
+    raise CredentialError immediately and never attempt the rest of the batch —
+    a bad credential is discovered after one call, not N. That first session is
+    kept as session #1 (not thrown away). `creator` is injectable so the batch
+    logic is testable without the `ant` CLI.
+    """
+    if not topics:
+        return []
+
+    created_ids = []
+
+    # Preflight: the first create is the credential probe, reused as session #1.
+    try:
+        created_ids.append(creator(agent_id, environment_id))
+    except SessionCreateError as exc:
+        raise CredentialError(str(exc)) from exc
+
+    # Batch: the credential is proven, create the rest.
+    for _ in topics[1:]:
+        created_ids.append(creator(agent_id, environment_id))
+
+    return assemble_sessions(created_ids, topics, workspace_id)
+
+
+def read_topics(topics_file):
+    """Read topics from a file — one topic per line, blank lines ignored."""
+    path = Path(topics_file)
+    if not path.exists():
+        print(f"Error: topics file not found: {topics_file}", file=sys.stderr)
+        sys.exit(EXIT_BAD_INPUT)
+    return [
+        line.strip()
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+
+def cmd_create(args):
+    """Create sessions for a batch of topics and write the run file."""
+    topics = read_topics(args.topics_file)
+    if not topics:
+        print("Error: no topics to dispatch.", file=sys.stderr)
+        sys.exit(EXIT_BAD_INPUT)
+
+    now = datetime.now(timezone.utc)
+    run_id = args.run_id or now.strftime("%Y%m%d-%H%M%S")
+    created_at = now.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    try:
+        sessions = create_sessions(
+            topics,
+            args.agent,
+            args.environment_id,
+            args.workspace_id,
+        )
+    except CredentialError as exc:
+        print(
+            f"Error: preflight session create failed — the credential is "
+            f"likely expired. Re-authenticate with `ant auth login`, then "
+            f"retry. ({exc})",
+            file=sys.stderr,
+        )
+        sys.exit(EXIT_BAD_CREDENTIAL)
+
+    run = build_run_file(
+        run_id,
+        args.agent,
+        args.environment_id,
+        args.workspace_id,
+        args.context,
+        sessions,
+        created_at,
+    )
+
+    run_file = args.run_file or f".dispatch-runs/{run_id}.json"
+    run_path = Path(run_file)
+    run_path.parent.mkdir(parents=True, exist_ok=True)
+    run_path.write_text(
+        json.dumps(run, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
+    )
+    print(f"Wrote run file: {run_file}", file=sys.stderr)
+
+    json.dump(
+        {"run_id": run_id, "run_file": run_file, "created": len(sessions)},
+        sys.stdout,
+        ensure_ascii=False,
+    )
+    sys.stdout.write("\n")
+    return EXIT_OK
+
+
+def build_parser():
+    parser = argparse.ArgumentParser(
+        prog="dispatch_create",
+        description="Create dispatch sessions and build the run file.",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_create = sub.add_parser(
+        "create",
+        help="Create one session per topic, with a credential preflight.",
+    )
+    p_create.add_argument("topics_file", help="File with one topic per line.")
+    p_create.add_argument("--agent", required=True, help="Agent ID.")
+    p_create.add_argument(
+        "--environment-id", required=True, dest="environment_id",
+        help="Environment ID.",
+    )
+    p_create.add_argument(
+        "--workspace-id", required=True, dest="workspace_id",
+        help="Workspace ID (for session URLs).",
+    )
+    p_create.add_argument("--context", default="", help="Run context label.")
+    p_create.add_argument(
+        "--run-id", dest="run_id",
+        help="Run ID (default: generated from the current timestamp).",
+    )
+    p_create.add_argument(
+        "--run-file", dest="run_file",
+        help="Run file path (default: .dispatch-runs/{run_id}.json).",
+    )
+    p_create.set_defaults(func=cmd_create)
+
+    return parser
+
+
+def main():
+    parser = build_parser()
+    args = parser.parse_args()
+    sys.exit(args.func(args))
+
+
+if __name__ == "__main__":
+    main()

--- a/claude/skills/dispatch/tests/test_dispatch_create.py
+++ b/claude/skills/dispatch/tests/test_dispatch_create.py
@@ -1,0 +1,103 @@
+"""Tests for dispatch_create.py — the drop-proof assembly core."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# Add scripts dir to path so we can import the module
+SCRIPTS_DIR = Path(__file__).parent.parent / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+import dispatch_create as dc
+
+
+WORKSPACE = "wrkspc_01EXAMPLE"
+
+
+class TestBuildSessionUrl:
+    def test_constructs_console_url(self):
+        url = dc.build_session_url(WORKSPACE, "sesn_01AA")
+        assert url == (
+            "https://console.anthropic.com/workspaces/"
+            "wrkspc_01EXAMPLE/sessions/sesn_01AA"
+        )
+
+
+class TestBuildSession:
+    def test_populates_creation_fields(self):
+        session = dc.build_session("Enterprise search", "sesn_01AA", 1, WORKSPACE)
+        assert session["id"] == "sesn_01AA"
+        assert session["topic"] == "Enterprise search"
+        assert session["url"] == dc.build_session_url(WORKSPACE, "sesn_01AA")
+
+    def test_leaves_gather_fields_null(self):
+        session = dc.build_session("Topic", "sesn_01AA", 1, WORKSPACE)
+        for field in (
+            "status",
+            "created_at",
+            "updated_at",
+            "output_tokens",
+            "result",
+            "output_file",
+        ):
+            assert session[field] is None
+
+
+class TestAssembleSessions:
+    def test_pairs_ids_and_topics_in_order(self):
+        ids = ["sesn_01A", "sesn_01B", "sesn_01C"]
+        topics = ["Alpha", "Beta", "Gamma"]
+        sessions = dc.assemble_sessions(ids, topics, WORKSPACE)
+
+        assert [s["id"] for s in sessions] == ids
+        assert [s["topic"] for s in sessions] == topics
+
+    def test_preserves_count_for_ten_sessions(self):
+        # The regression guard: DISPATCH.md Error 1 dropped the 10th session and
+        # blanked the 1st. Ten in, ten out, none blank.
+        ids = [f"sesn_{i:02d}" for i in range(1, 11)]
+        topics = [f"Topic {i}" for i in range(1, 11)]
+        sessions = dc.assemble_sessions(ids, topics, WORKSPACE)
+
+        assert len(sessions) == 10
+        assert all(s["id"] and s["topic"] for s in sessions)
+        assert sessions[0]["topic"] == "Topic 1"
+        assert sessions[-1]["topic"] == "Topic 10"
+
+    def test_empty_inputs_yield_empty_list(self):
+        assert dc.assemble_sessions([], [], WORKSPACE) == []
+
+    def test_length_mismatch_raises(self):
+        with pytest.raises(ValueError, match="count mismatch"):
+            dc.assemble_sessions(["sesn_01A"], ["Alpha", "Beta"], WORKSPACE)
+
+    def test_more_ids_than_topics_raises(self):
+        with pytest.raises(ValueError, match="count mismatch"):
+            dc.assemble_sessions(
+                ["sesn_01A", "sesn_01B"], ["Alpha"], WORKSPACE
+            )
+
+
+class TestBuildRunFile:
+    def test_assembles_top_level_structure(self):
+        sessions = dc.assemble_sessions(
+            ["sesn_01A"], ["Alpha"], WORKSPACE
+        )
+        run = dc.build_run_file(
+            run_id="20260605-085200",
+            agent_id="agent_01EXAMPLE",
+            environment_id="env_01EXAMPLE",
+            workspace_id=WORKSPACE,
+            context="PROJ-42 research",
+            sessions=sessions,
+            created_at="2026-06-05T08:52:00Z",
+        )
+
+        assert run["id"] == "20260605-085200"
+        assert run["created_at"] == "2026-06-05T08:52:00Z"
+        assert run["agent_id"] == "agent_01EXAMPLE"
+        assert run["environment_id"] == "env_01EXAMPLE"
+        assert run["workspace_id"] == WORKSPACE
+        assert run["context"] == "PROJ-42 research"
+        assert run["sessions"] == sessions

--- a/claude/skills/dispatch/tests/test_dispatch_create.py
+++ b/claude/skills/dispatch/tests/test_dispatch_create.py
@@ -1,6 +1,7 @@
 """Tests for dispatch_create.py — the drop-proof assembly core."""
 
 import sys
+import types
 from pathlib import Path
 
 import pytest
@@ -101,3 +102,89 @@ class TestBuildRunFile:
         assert run["workspace_id"] == WORKSPACE
         assert run["context"] == "PROJ-42 research"
         assert run["sessions"] == sessions
+
+
+class FakeCreator:
+    """A stand-in for create_one_session that records calls.
+
+    Returns sequential fake IDs, or raises SessionCreateError on the Nth call
+    (1-based) when `fail_on` is set — used to simulate a preflight failure.
+    """
+
+    def __init__(self, fail_on=None):
+        self.calls = 0
+        self.fail_on = fail_on
+
+    def __call__(self, agent_id, environment_id):
+        self.calls += 1
+        if self.fail_on is not None and self.calls == self.fail_on:
+            raise dc.SessionCreateError("simulated create failure")
+        return f"sesn_{self.calls:02d}"
+
+
+class TestCreateSessions:
+    def test_happy_path_creates_one_per_topic(self):
+        creator = FakeCreator()
+        topics = ["Alpha", "Beta", "Gamma"]
+        sessions = dc.create_sessions(
+            topics, "agent_01", "env_01", WORKSPACE, creator=creator
+        )
+
+        assert creator.calls == 3
+        assert [s["id"] for s in sessions] == ["sesn_01", "sesn_02", "sesn_03"]
+        assert [s["topic"] for s in sessions] == topics
+
+    def test_empty_topics_creates_nothing(self):
+        creator = FakeCreator()
+        assert dc.create_sessions(
+            [], "agent_01", "env_01", WORKSPACE, creator=creator
+        ) == []
+        assert creator.calls == 0
+
+    def test_preflight_failure_stops_after_one_call(self):
+        # A bad credential must be discovered after ONE create, not N.
+        creator = FakeCreator(fail_on=1)
+        with pytest.raises(dc.CredentialError):
+            dc.create_sessions(
+                ["Alpha", "Beta", "Gamma"],
+                "agent_01", "env_01", WORKSPACE, creator=creator,
+            )
+        assert creator.calls == 1  # never attempted the rest of the batch
+
+
+class TestCreateOneSession:
+    def test_parses_id_from_json(self, monkeypatch):
+        def fake_run(*args, **kwargs):
+            return types.SimpleNamespace(
+                returncode=0, stdout='{"id": "sesn_01ABC"}', stderr=""
+            )
+
+        monkeypatch.setattr(dc.subprocess, "run", fake_run)
+        assert dc.create_one_session("agent_01", "env_01") == "sesn_01ABC"
+
+    def test_nonzero_exit_raises(self, monkeypatch):
+        def fake_run(*args, **kwargs):
+            return types.SimpleNamespace(
+                returncode=1, stdout="", stderr="unauthorized"
+            )
+
+        monkeypatch.setattr(dc.subprocess, "run", fake_run)
+        with pytest.raises(dc.SessionCreateError, match="unauthorized"):
+            dc.create_one_session("agent_01", "env_01")
+
+    def test_missing_id_raises(self, monkeypatch):
+        def fake_run(*args, **kwargs):
+            return types.SimpleNamespace(
+                returncode=0, stdout='{"foo": "bar"}', stderr=""
+            )
+
+        monkeypatch.setattr(dc.subprocess, "run", fake_run)
+        with pytest.raises(dc.SessionCreateError, match="no `id`"):
+            dc.create_one_session("agent_01", "env_01")
+
+
+class TestReadTopics:
+    def test_reads_one_per_line_ignoring_blanks(self, tmp_path):
+        f = tmp_path / "topics.txt"
+        f.write_text("Alpha\n\nBeta\n  \nGamma\n")
+        assert dc.read_topics(str(f)) == ["Alpha", "Beta", "Gamma"]


### PR DESCRIPTION
## Summary
- Splits the infrastructure riders out of VID-699. Moves dispatch session creation off fragile zsh arrays — 1-indexed loops blanked the first session and dropped the last (DISPATCH.md Error 1) — into a tested Python module.
- **Step 1 (this commit):** drop-proof assembly core — order-preserving id/topic pairing with a hard length guard that errors instead of silently dropping. Pure, CLI-free functions; 9 unit tests including a 10-session regression guard.

## Scope / status
- **Stacked on #94 (VID-699).** Base is the VID-699 branch, not `main` — merge VID-699 first, then this retargets to `main`.
- **WIP** — still to come: Step 2 (`ant` create wrapper + credential preflight, reuse-as-#1 fail-fast) and Step 3 (wire `SKILL.md` Phase 1 to call the script; mark `DISPATCH.md` Error 1 resolved).

## Test plan
- `uv run pytest tests/test_dispatch_create.py` — 9 passing.

Closes VID-705

🤖 Generated with [Claude Code](https://claude.com/claude-code)