### PR TITLE
feat(nix): migrate Ollama from nix to Homebrew [VID-594]

### DIFF
--- a/README.org
+++ b/README.org
@@ -5678,12 +5678,12 @@ Just in case the internet fails, we want to have a OSS coding tool that can wiel
 
 [[https://github.com/ollama/ollama][Ollama]] is a convenient CLI tool to spin up LLMs locally for inference anad and to spawn local APIs that can be used with locally running tools. This should come in handy for offline LLM access and the general development of LLM-powered builds... even when the internet is down or when flying.
 
-**** COMMENT Install Ollama through homebrew
+**** Install Ollama through homebrew
 
-On MacOS, we install Ollama using the [[https://formulae.brew.sh/formula/ollama][brew]]:
+Enabled <2026-07-27> (VID-594): Ollama now comes from the [[https://formulae.brew.sh/formula/ollama][brew formula]] instead of nixpkgs, which tracks a newer release (the nixpkgs pin 0.20.7 is too old for Gemma 4). The object-form entry sets =start_service = true= so nix-darwin owns the =brew services= daemon — replacing the custom launchd agent we used under the nix package.
 
 #+begin_src nix :noweb-ref homebrew-brews :noweb yes
-"ollama"
+{ name = "ollama"; start_service = true; }
 #+end_src
 
 **** COMMENT Install Ollama from nix packages
@@ -5738,6 +5738,10 @@ ollama pull qwen3:8b                       # ~5 GB
 
 # 5. (Optional) Best-in-class tool-calling generalist (#2 on BFCL v3, 75.7%)
 ollama pull qwen3:32b                      # ~20 GB
+
+# 6. Google Gemma 4 — multimodal, reasoning, 256k context. General-purpose
+#    desktop pick (VID-594). Needs the Homebrew Ollama; nixpkgs 0.20.7 is too old.
+ollama pull gemma4:12b                      # ~8 GB
 #+end_src
 
 ***** Why these picks

--- a/README.org
+++ b/README.org
@@ -5686,7 +5686,9 @@ On MacOS, we install Ollama using the [[https://formulae.brew.sh/formula/ollama]
 "ollama"
 #+end_src
 
-**** Install Ollama from nix packages
+**** COMMENT Install Ollama from nix packages
+
+Disabled <2026-07-25> (VID-594): migrating Ollama from nix to Homebrew so we track a newer release. Gemma 4 needs an Ollama newer than the nixpkgs-pinned 0.20.7 (=412: model requires a newer version of Ollama=). Staged migration — this block is commented first, applied via =make nix-darwin-switch=, then the Homebrew block above is enabled in a second switch.
 
 We still need to clean up my config to reuse the old dev.nix:
 
@@ -5762,7 +5764,9 @@ For Mixture-of-Experts models, *total* parameters live in RAM, but only *active*
 - Reach for raw =mlx-lm= / LM Studio only when benchmarking or hosting a single high-throughput inference endpoint (~130 tok/s vs ~71 for llama.cpp on large models).
 - Stay on GGUF/ollama for anything talking the OpenAI API, Continue.dev, agent integrations, or juggling multiple models.
 
-**** Auto-start the daemon via launchd
+**** COMMENT Auto-start the daemon via launchd
+
+Disabled <2026-07-25> (VID-594): this agent references =${pkgs.ollama}=, which would keep nix building Ollama even after the package block above is commented. Once Ollama moves to Homebrew, the daemon is owned by the Homebrew service (=start_service= on the object-form brew entry) instead of this custom launchd agent.
 
 Manual =ollama serve= is how we end up with a stale 0.15.6 daemon still running 6 days after a =darwin-rebuild switch= — the binary on PATH gets upgraded but the long-lived process keeps holding a file descriptor to the old store path. We can't trust ourselves to remember; let nix-darwin own the daemon's lifecycle.
 

--- a/README.org
+++ b/README.org
@@ -2884,6 +2884,14 @@ ghidra-bin
 "framer"
 #+end_src
 
+**** Paper
+
+[[https://paper.design/][Paper]] is a web-based "connected canvas" design tool for building interfaces and prototypes on web standards (HTML/CSS), with real-time design↔code sync and AI-agent/MCP integration. Installed via the [[https://formulae.brew.sh/cask/paper-design][=paper-design= cask]] (arm64, macOS >= 12).
+
+#+begin_src nix :noweb-ref homebrew-casks :noweb yes
+"paper-design"
+#+end_src
+
 **** Rive
 
 [[https://rive.app][Rive]], like Lottie provides tooling to animate assets for mobile apps but unlike Lottie owns the E2E stack where Lottie requires the use of multiple disconnected tools in order to author Lottie animations. Rive furthermore boasts support for state-aware animations.

--- a/configuration-darwin.nix
+++ b/configuration-darwin.nix
@@ -197,6 +197,7 @@ with lib;
       "pcalc"
       "duti"
       "anomalyco/tap/opencode"
+      { name = "ollama"; start_service = true; }
       "pi-coding-agent"
     ];
     casks = builtins.filter (x: x != null) [

--- a/configuration-darwin.nix
+++ b/configuration-darwin.nix
@@ -216,6 +216,7 @@ with lib;
       "figma"
       "open-design"
       "framer"
+      "paper-design"
       "rive"
       "docker-desktop"
       "utm"

--- a/configuration-darwin.nix
+++ b/configuration-darwin.nix
@@ -266,27 +266,4 @@ with lib;
   ];
 
   environment.pathsToLink = [ "/share/myspell" "/share/hunspell" ];
-  launchd.user.agents.ollama = {
-    serviceConfig = {
-      ProgramArguments = [
-        "${pkgs.ollama}/bin/ollama"
-        "serve"
-      ];
-
-      # Start at login, restart on any exit
-      RunAtLoad = true;
-      KeepAlive = true;
-      # Headless daemon, not a foreground app
-      ProcessType = "Background";
-
-      # Logs land here; truncate manually if they grow
-      StandardOutPath = "/Users/${username}/Library/Logs/ollama.stdout.log";
-      StandardErrorPath = "/Users/${username}/Library/Logs/ollama.stderr.log";
-    };
-
-    # launchd's default PATH is /usr/bin:/bin:/usr/sbin:/sbin which is too narrow
-    path = [
-      config.environment.systemPath
-    ];
-  };
 }

--- a/home-darwin.nix
+++ b/home-darwin.nix
@@ -65,7 +65,6 @@
     pkgs.fswatch
     pkgs.gemini-cli
     pkgs.codex
-    pkgs.ollama
     pkgs.llama-cpp
     # home-darwin-packages
     pywal


### PR DESCRIPTION
## Summary
Gemma 4 needs a newer Ollama than the nixpkgs-pinned `0.20.7` — `ollama pull gemma4:12b` fails with `412: model requires a newer version of Ollama`. Migrate Ollama from nix to Homebrew (newer, auto-updating), **staged** so the two package managers never both own the binary/daemon at once.

## Staged migration
- **Stage 1 (committed):** comment out nix `pkgs.ollama` + the custom launchd `ollama serve` agent (it referenced `${pkgs.ollama}`, which would keep nix building Ollama). Apply: `make nix-darwin-switch` → nix Ollama removed.
- **Stage 2 (next commit):** enable the Homebrew `ollama` formula with a managed service (`start_service`), and add the `gemma4:12b` pull line to the offline-models runbook. Apply: `make nix-darwin-switch` → Homebrew Ollama installed.
- Then: `ollama pull gemma4:12b`.

## Notes
- Commits are **unsigned** (remote/mobile session — Touch ID unavailable; the intended "AI-produced" signal). Merge needs explicit human review.
- Each stage's `make nix-darwin-switch` is an at-the-machine step (sudo/Touch-ID).

## Test plan
- After the stage-2 switch: `ollama --version` shows the Homebrew build; `ollama pull gemma4:12b` succeeds; `ollama run gemma4:12b` responds.

VID-594
