### PR TITLE
feat(nix): add Paper design app via Homebrew cask [VID-706]

### DIFF
--- a/README.org
+++ b/README.org
@@ -2884,6 +2884,14 @@ ghidra-bin
 "framer"
 #+end_src
 
+**** Paper
+
+[[https://paper.design/][Paper]] is a web-based "connected canvas" design tool for building interfaces and prototypes on web standards (HTML/CSS), with real-time design↔code sync and AI-agent/MCP integration. Installed via the [[https://formulae.brew.sh/cask/paper-design][=paper-design= cask]] (arm64, macOS >= 12).
+
+#+begin_src nix :noweb-ref homebrew-casks :noweb yes
+"paper-design"
+#+end_src
+
 **** Rive
 
 [[https://rive.app][Rive]], like Lottie provides tooling to animate assets for mobile apps but unlike Lottie owns the E2E stack where Lottie requires the use of multiple disconnected tools in order to author Lottie animations. Rive furthermore boasts support for state-aware animations.

--- a/configuration-darwin.nix
+++ b/configuration-darwin.nix
@@ -216,6 +216,7 @@ with lib;
       "figma"
       "open-design"
       "framer"
+      "paper-design"
       "rive"
       "docker-desktop"
       "utm"


### PR DESCRIPTION
## Summary
Add the `paper-design` Homebrew cask so **Paper** — a web-based connected-canvas UI design tool with real-time design↔code sync and MCP/agent integration — installs declaratively. Declared alongside the other design casks (Figma / Open Design / Framer / Rive).

## Notes
- Commits are **unsigned** (remote/mobile session).
- **Install step:** `make nix-darwin-switch` (sudo/Touch-ID at the machine) installs `Paper.app`. arm64 / macOS ≥ 12.

## Test plan
- After the switch: `Paper.app` appears in `/Applications` and launches.
- `brew list --cask | grep paper-design`.

VID-706
