### PR TITLE
fix: trust third-party Homebrew taps before darwin switch [VID-709]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,9 +65,6 @@ check-config: tangle verify-parity validate
 nix-darwin-build:
 	${DARWIN_REBUILD} check --flake .#${HOSTNAME}
 
-# Deploy nix-darwin configuration (builds and activates)
-# Actually switches your system to the new configuration
-# Use after testing with nix-darwin-build
 # Trust third-party Homebrew taps so `brew bundle` (run during the switch)
 # doesn't abort on an untrusted tap. Idempotent; runs as the invoking user,
 # which is the context whose trust.json the bundle reads.
@@ -76,6 +73,9 @@ trust-taps:
 	@echo "🔐 Trusting third-party Homebrew taps..."
 	@for tap in ${TRUSTED_TAPS}; do brew trust "$$tap"; done
 
+# Deploy nix-darwin configuration (builds and activates)
+# Actually switches your system to the new configuration
+# Use after testing with nix-darwin-build
 .PHONY: nix-darwin-switch
 nix-darwin-switch: trust-taps
 	${DARWIN_REBUILD} switch --flake .#${HOSTNAME}

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,12 @@ NIX_SHELL = nix-shell
 DARWIN_REBUILD = sudo darwin-rebuild
 HOSTNAME := $(shell hostname)
 
+# Third-party Homebrew taps that must be trusted before `brew bundle` runs —
+# Homebrew refuses to load formulae/casks from untrusted taps. `brew trust` is
+# idempotent, so we just re-assert these on every switch (no state to track).
+# Add new third-party taps here.
+TRUSTED_TAPS = felixkratz/formulae anomalyco/tap anthropics/tap
+
 # Tangle all org files to generate configuration files
 # Respects local variables in org files (e.g., trailing whitespace cleanup hooks)
 .PHONY: tangle
@@ -62,8 +68,16 @@ nix-darwin-build:
 # Deploy nix-darwin configuration (builds and activates)
 # Actually switches your system to the new configuration
 # Use after testing with nix-darwin-build
+# Trust third-party Homebrew taps so `brew bundle` (run during the switch)
+# doesn't abort on an untrusted tap. Idempotent; runs as the invoking user,
+# which is the context whose trust.json the bundle reads.
+.PHONY: trust-taps
+trust-taps:
+	@echo "🔐 Trusting third-party Homebrew taps..."
+	@for tap in ${TRUSTED_TAPS}; do brew trust "$$tap"; done
+
 .PHONY: nix-darwin-switch
-nix-darwin-switch:
+nix-darwin-switch: trust-taps
 	${DARWIN_REBUILD} switch --flake .#${HOSTNAME}
 
 # Default target - show help

--- a/README.org
+++ b/README.org
@@ -114,6 +114,12 @@ NIX_SHELL = nix-shell
 DARWIN_REBUILD = sudo darwin-rebuild
 HOSTNAME := $(shell hostname)
 
+# Third-party Homebrew taps that must be trusted before `brew bundle` runs —
+# Homebrew refuses to load formulae/casks from untrusted taps. `brew trust` is
+# idempotent, so we just re-assert these on every switch (no state to track).
+# Add new third-party taps here.
+TRUSTED_TAPS = felixkratz/formulae anomalyco/tap anthropics/tap
+
 # Tangle all org files to generate configuration files
 # Respects local variables in org files (e.g., trailing whitespace cleanup hooks)
 .PHONY: tangle
@@ -158,11 +164,19 @@ check-config: tangle verify-parity validate
 nix-darwin-build:
 	${DARWIN_REBUILD} check --flake .#${HOSTNAME}
 
+# Trust third-party Homebrew taps so `brew bundle` (run during the switch)
+# doesn't abort on an untrusted tap. Idempotent; runs as the invoking user,
+# which is the context whose trust.json the bundle reads.
+.PHONY: trust-taps
+trust-taps:
+	@echo "🔐 Trusting third-party Homebrew taps..."
+	@for tap in ${TRUSTED_TAPS}; do brew trust "$$tap"; done
+
 # Deploy nix-darwin configuration (builds and activates)
 # Actually switches your system to the new configuration
 # Use after testing with nix-darwin-build
 .PHONY: nix-darwin-switch
-nix-darwin-switch:
+nix-darwin-switch: trust-taps
 	${DARWIN_REBUILD} switch --flake .#${HOSTNAME}
 
 # Default target - show help


### PR DESCRIPTION
## Summary
Homebrew now refuses to load formulae/casks from untrusted third-party taps, aborting `brew bundle` and therefore `make nix-darwin-switch` (hit on VID-594 — `felixkratz/formulae`, `anomalyco/tap`, `anthropics/tap` each needed a manual `brew trust`).

Add a `trust-taps` prerequisite to `nix-darwin-switch` that re-asserts trust on the declared `TRUSTED_TAPS` before `darwin-rebuild`. `brew trust` is idempotent, so there's no state to track.

## Why the Makefile (not nix config)
- nix-darwin's homebrew module has **no pre-bundle command hook** (only `extraEnv` / `extraFlags` / `global.brewfile`).
- Trust is **per-user** (`~/.config/homebrew/trust.json`); `brew bundle` reads the *invoking user's* store. The Makefile runs `brew trust` as the user → correct store. An in-nix `system.activationScripts` entry runs as **root** → wrong store.
- The only fully-in-nix env-var (`HOMEBREW_NO_REQUIRE_TAP_TRUST`) is "not recommended" and slated for removal — and would disable trust for *all* taps.

## Notes
- Commit **unsigned** (remote session).
- Adding a new third-party tap = one line in `TRUSTED_TAPS`.

## Test plan
- `make trust-taps` trusts the three taps idempotently (verified — re-running succeeds).
- `make nix-darwin-switch` now runs `trust-taps` before the switch.

VID-709
